### PR TITLE
fix: Remove authentication for SendChangePasswordEmail API

### DIFF
--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -796,7 +796,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -830,7 +830,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -864,7 +864,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -898,7 +898,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -932,7 +932,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -966,7 +966,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1000,7 +1000,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1034,7 +1034,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1068,7 +1068,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1102,7 +1102,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1137,7 +1137,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1172,7 +1172,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1207,7 +1207,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1242,7 +1242,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1276,7 +1276,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1310,7 +1310,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1344,7 +1344,7 @@ Resources:
             - ":"
             - !Ref "AWS::AccountId"
             - ":layer:"
-            - "WalterAILambdaLayer:28"
+            - "WalterAILambdaLayer:29"
       Environment:
         Variables:
           DOMAIN: DEVELOPMENT
@@ -1378,7 +1378,7 @@ Resources:
               - ":"
               - !Ref "AWS::AccountId"
               - ":layer:"
-              - "WalterAILambdaLayer:28"
+              - "WalterAILambdaLayer:29"
         Environment:
           Variables:
             DOMAIN: DEVELOPMENT
@@ -1582,6 +1582,16 @@ Resources:
                 - !Ref "AWS::Region"
                 - ":"
                 - !Ref "AWS::AccountId"
+                - ":secret:AlphaVantagePremiumAPIKey-xB99wz"
+          - Effect: Allow
+            Action:
+              - "secretsmanager:GetSecretValue"
+            Resource: !Join
+              - ""
+              - - "arn:aws:secretsmanager:"
+                - !Ref "AWS::Region"
+                - ":"
+                - !Ref "AWS::AccountId"
                 - ":secret:PolygonAPIKey-vZymuJ"
           - Effect: Allow
             Action:
@@ -1722,37 +1732,6 @@ Resources:
   ##########
   ### S3 ###
   ##########
-
-  KnowledgeBaseBucket:
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    Properties:
-      BucketName: !Sub "walter-knowledge-base-${AppEnvironment}"
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: "AES256"
-      VersioningConfiguration:
-        Status: Enabled
-      LifecycleConfiguration:
-        Rules:
-          - Id: "DeleteOldKnowledge"
-            Status: "Enabled"
-            ExpirationInDays: 365
-
-  KnowledgeBaseBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref KnowledgeBaseBucket
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Action:
-              - "s3:PutObject"
-            Effect: Allow
-            Resource: !Sub "${NewslettersBucket.Arn}/*"
-            Principal:
-              AWS: !GetAtt WalterBackendRole.Arn
 
   NewslettersBucket:
     Type: AWS::S3::Bucket

--- a/src/api/send_change_password_email.py
+++ b/src/api/send_change_password_email.py
@@ -15,7 +15,7 @@ from src.templates.engine import TemplatesEngine
 class SendChangePasswordEmail(WalterAPIMethod):
 
     API_NAME = "SendChangePasswordEmail"
-    REQUIRED_HEADERS = {"Authorization": "Bearer"}
+    REQUIRED_HEADERS = {}
     REQUIRED_QUERY_FIELDS = ["email"]
     REQUIRED_FIELDS = []
     EXCEPTIONS = [BadRequest, UserDoesNotExist]

--- a/src/knowledge/base.py
+++ b/src/knowledge/base.py
@@ -33,7 +33,7 @@ class WalterKnowledgeBase:
         for title, contents in news.news.items():
             self._dump_article(stock, title, contents)
         log.info(
-            "Successfully dumped news for company '{news.symbol}' to knowledge base!"
+            f"Successfully dumped news for company '{news.symbol}' to knowledge base!"
         )
 
     def _dump_article(self, symbol: str, title: str, contents: str) -> None:

--- a/src/stocks/alphavantage/client.py
+++ b/src/stocks/alphavantage/client.py
@@ -105,7 +105,7 @@ class AlphaVantageClient:
     def _get_news_url(self, symbol: str, time_from: dt.datetime = ONE_YEAR_AGO) -> str:
         return self._get_method_url(
             method="NEWS_SENTIMENT",
-            args={"symbol": symbol, "time_from": time_from.strftime("%Y%m%dT%H%M")},
+            args={"tickers": symbol, "time_from": time_from.strftime("%Y%m%dT%H%M")},
         )
 
     def _get_method_url(self, method: str, args: dict) -> str:


### PR DESCRIPTION
This PR fixes some bugs after not working on Walter for quite some time.

I logged onto the site and the `SendChangePasswordEmail` API was failing due to a client bad request error missing auth token... That API shouldn't require auth so must've just left Walter in a bit of a broken state 😅 

Anyways, this fixes the immediate bugs I found after testing the site a bit. 