### PR TITLE
feat: Add more company details to Stocks table

### DIFF
--- a/src/database/stocks/models.py
+++ b/src/database/stocks/models.py
@@ -13,8 +13,12 @@ class Stock:
 
     symbol: str
     company: str
+    exchange: str = "N/A"
     sector: str = "N/A"
     industry: str = "N/A"
+    description: str = "N/A"
+    official_site: str = "N/A"
+    address: str = "N/A"
 
     def to_ddb_item(self) -> dict:
         """
@@ -29,8 +33,12 @@ class Stock:
                 "S": self.symbol,
             },
             "company": {"S": self.company},
+            "exchange": {"S": self.exchange},
             "sector": {"S": self.sector},
             "industry": {"S": self.industry},
+            "description": {"S": self.description},
+            "official_site": {"S": self.official_site},
+            "address": {"S": self.address},
         }
 
     def to_dict(self) -> dict:
@@ -44,6 +52,10 @@ class Stock:
         return {
             "symbol": self.symbol,
             "company": self.company,
+            "exchange": self.exchange,
             "sector": self.sector,
             "industry": self.industry,
+            "description": self.description,
+            "official_site": self.official_site,
+            "address": self.address,
         }

--- a/src/database/stocks/table.py
+++ b/src/database/stocks/table.py
@@ -120,6 +120,10 @@ class StocksTable:
         return Stock(
             symbol=item["symbol"]["S"],
             company=item["company"]["S"],
+            exchange=item["exchange"]["S"],
             sector=item["sector"]["S"],
             industry=item["industry"]["S"],
+            description=item["description"]["S"],
+            official_site=item["official_site"]["S"],
+            address=item["address"]["S"],
         )

--- a/src/stocks/alphavantage/client.py
+++ b/src/stocks/alphavantage/client.py
@@ -57,6 +57,7 @@ class AlphaVantageClient:
             sector=response["Sector"],
             industry=response["Industry"],
             official_site=response["OfficialSite"],
+            address=response["Address"],
         )
         log.info(
             f"Returned company overview for '{symbol}':\n{json.dumps(overview.to_dict(), indent=4)}"

--- a/src/stocks/alphavantage/models.py
+++ b/src/stocks/alphavantage/models.py
@@ -17,6 +17,7 @@ class CompanyOverview:
     sector: str
     industry: str
     official_site: str
+    address: str
 
     def to_dict(self) -> dict:
         return {
@@ -27,6 +28,7 @@ class CompanyOverview:
             "sector": self.sector,
             "industry": self.industry,
             "official_site": self.official_site,
+            "address": self.address,
         }
 
 

--- a/src/stocks/client.py
+++ b/src/stocks/client.py
@@ -58,6 +58,10 @@ class WalterStocksAPI:
         return Stock(
             symbol=overview.symbol,
             company=overview.name,
+            exchange=overview.exchange,
             sector=overview.sector,
             industry=overview.industry,
+            description=overview.description,
+            official_site=overview.official_site,
+            address=overview.address,
         )

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -357,6 +357,7 @@ def walter_stocks_api(mocker) -> WalterStocksAPI:
                     sector=aapl.sector,
                     industry=aapl.industry,
                     official_site="https://walterai.dev",
+                    address=aapl.address,
                 ),
                 meta.symbol: CompanyOverview(
                     symbol=meta.symbol,
@@ -366,6 +367,7 @@ def walter_stocks_api(mocker) -> WalterStocksAPI:
                     sector=meta.sector,
                     industry=meta.industry,
                     official_site="https://walterai.dev",
+                    address=meta.address,
                 ),
                 abnb.symbol: CompanyOverview(
                     symbol=abnb.symbol,
@@ -375,6 +377,7 @@ def walter_stocks_api(mocker) -> WalterStocksAPI:
                     sector=abnb.sector,
                     industry=abnb.industry,
                     official_site="https://walterai.dev",
+                    address=abnb.address,
                 ),
             }
 


### PR DESCRIPTION
This PR adds more company details returned by AlphaVantage in the `GetCompanyOverview` API to the corresponding Stock model in WalterDB.

Kind of odd to map the `GetCompanyOverview` API return to the Stocks table... makes me think I should refactor the table name to something like Companies and have a separate Stocks table... future CR...

