### PR TITLE
test: Add unit tests for GetPrices API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: pytest # unit tests
         name: pytest
         description: "Pytest: Helps you write less buggy code"
-        entry: pipenv run coverage run -m pytest
+        entry: pipenv run coverage run -m pytest -vv
         language: python
         types: [ python ]
         pass_filenames: false

--- a/cli.py
+++ b/cli.py
@@ -19,6 +19,7 @@ from tst.api.utils import (
     get_unsubscribe_event,
     get_subscribe_event,
     get_news_summary_event,
+    get_get_prices_event,
 )
 from tst.events.utils import get_walter_backend_event
 from walter import (
@@ -37,6 +38,7 @@ from walter import (
     unsubscribe_entrypoint,
     subscribe_entrypoint,
     get_news_summary_entrypoint,
+    get_prices_entrypoint,
 )
 
 log = Logger(__name__).get_logger()
@@ -89,6 +91,14 @@ def add_stock(token: str = None, stock: str = None, quantity: float = None) -> N
     log.info("Walter CLI: Adding stock...")
     event = get_add_stock_event(stock, quantity, token)
     response = add_stock_entrypoint(event, CONTEXT)
+    log.info(f"Walter CLI: Response:\n{parse_response(response)}")
+
+
+@app.command()
+def get_prices(stock: str = None) -> None:
+    log.info("Walter CLI: Getting prices...")
+    event = get_get_prices_event(stock)
+    response = get_prices_entrypoint(event, CONTEXT)
     log.info(f"Walter CLI: Response:\n{parse_response(response)}")
 
 

--- a/src/api/get_prices.py
+++ b/src/api/get_prices.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import dataclass
+from typing import List
 
 from src.api.common.exceptions import BadRequest, StockDoesNotExist
 from src.api.common.methods import HTTPStatus, Status
@@ -7,11 +8,21 @@ from src.api.common.methods import WalterAPIMethod
 from src.auth.authenticator import WalterAuthenticator
 from src.aws.cloudwatch.client import WalterCloudWatchClient
 from src.database.client import WalterDB
+from src.database.stocks.models import Stock
 from src.stocks.client import WalterStocksAPI
+from src.stocks.polygon.models import StockPrice
+from src.utils.log import Logger
+
+log = Logger(__name__).get_logger()
 
 
 @dataclass
 class GetPrices(WalterAPIMethod):
+    """
+    WalterAPI: GetPrices
+
+    This API gets the latest time-series pricing data for the given stock.
+    """
 
     API_NAME = "GetPrices"
     REQUIRED_HEADERS = {"content-type": "application/json"}
@@ -42,24 +53,41 @@ class GetPrices(WalterAPIMethod):
     def execute(self, event: dict, authenticated_email: str) -> dict:
         body = json.loads(event["body"])
         stock = body["stock"]
-        prices = self.walter_stocks_api.get_prices(stock).prices
+        stock = self._verify_stock_exists(stock)
+        prices = self._get_prices(stock)
         return self._create_response(
             http_status=HTTPStatus.OK,
             status=Status.SUCCESS,
             message="Retrieved prices!",
-            data={"stock": stock, "prices": [prices.to_dict() for prices in prices]},
+            data={
+                "stock": stock.symbol,
+                "prices": [prices.to_dict() for prices in prices],
+            },
         )
 
     def validate_fields(self, event: dict) -> None:
-        body = json.loads(event["body"])
-
-        symbol = body["stock"]
-        stock = self.walter_stocks_api.get_stock(symbol)
-        if stock is None:
-            raise StockDoesNotExist("Stock does not exist!")
-
-        if self.walter_db.get_stock(symbol) is None:
-            self.walter_db.add_stock(stock)
+        pass
 
     def is_authenticated_api(self) -> bool:
         return False
+
+    def _verify_stock_exists(self, symbol: str) -> Stock | None:
+        log.info("Verifying stock exists...")
+        cached_stock = self.walter_db.get_stock(symbol)
+        if cached_stock is None:
+            log.info("Stock not found in WalterDB. Checking AlphaVantage...")
+            stock = self.walter_stocks_api.get_stock(symbol)
+            if stock is None:
+                log.error("Stock does not exist!")
+                raise StockDoesNotExist("Stock does not exist!")
+            log.info("Adding stock to WalterDB...")
+            self.walter_db.add_stock(stock)
+            return stock
+        log.info(
+            f"Stock found in WalterDB:\n{json.dumps(cached_stock.to_dict(), indent=4)}"
+        )
+        return cached_stock
+
+    def _get_prices(self, stock: Stock) -> List[StockPrice]:
+        log.info("Getting prices from Polygon")
+        return self.walter_stocks_api.get_prices(stock.symbol).prices

--- a/tst/api/test_get_prices.py
+++ b/tst/api/test_get_prices.py
@@ -1,0 +1,129 @@
+import pytest
+
+from src.api.common.methods import Status, HTTPStatus
+from src.api.get_prices import GetPrices
+from src.auth.authenticator import WalterAuthenticator
+from src.aws.cloudwatch.client import WalterCloudWatchClient
+from src.aws.secretsmanager.client import WalterSecretsManagerClient
+from src.database.client import WalterDB
+from src.database.stocks.models import Stock
+from src.stocks.client import WalterStocksAPI
+from tst.api.utils import get_get_prices_event, get_expected_response
+
+META = Stock(
+    symbol="META",
+    company="Meta Platforms Inc.",
+    description="Meta Platforms, Inc. develops products that enable people to connect and share with friends and family through mobile devices, PCs, virtual reality headsets, wearables and home devices around the world. The company is headquartered in Menlo Park, California.",
+    exchange="NASDAQ",
+    sector="TECHNOLOGY",
+    industry="SERVICES-COMPUTER PROGRAMMING, DATA PROCESSING, ETC.",
+    official_site="https://investor.fb.com",
+    address="1601 WILLOW ROAD, MENLO PARK, CA, US",
+)
+
+ABNB = Stock(
+    symbol="ABNB",
+    company="Airbnb",
+    exchange="NYSE",
+    sector="Trade & Services",
+    industry="Lodging",
+    official_site="https://walterai.dev",
+)
+
+
+@pytest.fixture
+def get_prices_api(
+    walter_authenticator: WalterAuthenticator,
+    walter_cw: WalterCloudWatchClient,
+    walter_db: WalterDB,
+    walter_stocks_api: WalterStocksAPI,
+    walter_sm: WalterSecretsManagerClient,
+) -> GetPrices:
+    return GetPrices(walter_authenticator, walter_cw, walter_db, walter_stocks_api)
+
+
+def test_get_prices_success_exists_in_db(
+    get_prices_api: GetPrices, walter_db: WalterDB
+) -> None:
+    event = get_get_prices_event(symbol=META.symbol)
+    expected_response = get_expected_response(
+        api_name=get_prices_api.API_NAME,
+        status_code=HTTPStatus.OK,
+        status=Status.SUCCESS,
+        message="Retrieved prices!",
+        data={
+            "stock": META.symbol,
+            "prices": [
+                {
+                    "symbol": META.symbol,
+                    "price": 200.0,
+                    "timestamp": "2024-10-01T00:00:00",
+                },
+                {
+                    "symbol": META.symbol,
+                    "price": 225.0,
+                    "timestamp": "2024-10-01T01:00:00",
+                },
+                {
+                    "symbol": META.symbol,
+                    "price": 250.0,
+                    "timestamp": "2024-10-01T02:00:00",
+                },
+            ],
+        },
+    )
+    assert walter_db.get_stock(META.symbol) is not None
+    assert expected_response == get_prices_api.invoke(event)
+
+
+def test_get_prices_success_does_not_exist_in_db(
+    get_prices_api: GetPrices, walter_db: WalterDB
+) -> None:
+    event = get_get_prices_event(symbol=ABNB.symbol)
+    expected_response = get_expected_response(
+        api_name=get_prices_api.API_NAME,
+        status_code=HTTPStatus.OK,
+        status=Status.SUCCESS,
+        message="Retrieved prices!",
+        data={
+            "stock": ABNB.symbol,
+            "prices": [
+                {
+                    "symbol": ABNB.symbol,
+                    "price": 1000.0,
+                    "timestamp": "2024-10-01T00:00:00",
+                },
+                {
+                    "symbol": ABNB.symbol,
+                    "price": 1005.0,
+                    "timestamp": "2024-10-01T01:00:00",
+                },
+                {
+                    "symbol": ABNB.symbol,
+                    "price": 1006.0,
+                    "timestamp": "2024-10-01T02:00:00",
+                },
+            ],
+        },
+    )
+    assert walter_db.get_stock(ABNB.symbol) is None
+    assert expected_response == get_prices_api.invoke(event)
+    assert walter_db.get_stock(ABNB.symbol) is not None
+
+
+def test_get_prices_failure_stock_does_not_exist(
+    get_prices_api: GetPrices,
+    walter_db: WalterDB,
+    walter_stocks_api: WalterStocksAPI,
+) -> None:
+    invalid_symbol = "INVALID"
+    event = get_get_prices_event(symbol=invalid_symbol)
+    expected_response = get_expected_response(
+        api_name=get_prices_api.API_NAME,
+        status_code=HTTPStatus.OK,
+        status=Status.FAILURE,
+        message="Stock does not exist!",
+    )
+    assert walter_stocks_api.get_stock(invalid_symbol) is None
+    assert walter_db.get_stock(invalid_symbol) is None
+    assert expected_response == get_prices_api.invoke(event)

--- a/tst/api/utils.py
+++ b/tst/api/utils.py
@@ -37,6 +37,12 @@ def get_delete_stock_event(stock: str, token: str) -> dict:
     return EVENT
 
 
+def get_get_prices_event(symbol: str) -> dict:
+    EVENT["body"] = json.dumps({"stock": symbol})
+    EVENT["headers"] = {"content-type": "application/json"}
+    return EVENT
+
+
 def get_portfolio_event(token: str) -> dict:
     EVENT["headers"] = {"Authorization": f"Bearer {token}"}
     return EVENT

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -296,6 +296,29 @@ def walter_stocks_api(mocker) -> WalterStocksAPI:
                     timestamp=end_date.timestamp() * 1000,
                 ),
             ],
+            abnb.symbol: [
+                Agg(
+                    open=1000.0,
+                    high=1025.0,
+                    low=998.0,
+                    close=1001.0,
+                    timestamp=start_date.timestamp() * 1000,
+                ),
+                Agg(
+                    open=1005.0,
+                    high=1050.0,
+                    low=1001.0,
+                    close=1004.0,
+                    timestamp=(start_date + timedelta(hours=1)).timestamp() * 1000,
+                ),
+                Agg(
+                    open=1006.0,
+                    high=1042.0,
+                    low=1005.0,
+                    close=1006.0,
+                    timestamp=end_date.timestamp() * 1000,
+                ),
+            ],
         }
         for key, value in kwargs.items():
             if key == "ticker":


### PR DESCRIPTION
This CR adds unit tests for the `GetPrices` API.

Also, adds a fix where Walter checks WalterDB first for the existence of a stock before defaulting to AlphaVantage... Will reduce call volume on AlphaVantage which is probably desirable.

Calls to DDB with cached info seem better from network call/latency standpoint. 