### PR TITLE
test: Add unit tests for NewsSummariesBucket client

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,4 @@ omit =
 
 [report]
 show_missing = True
-fail_under = 50
+fail_under = 60

--- a/src/aws/s3/client.py
+++ b/src/aws/s3/client.py
@@ -68,7 +68,7 @@ class WalterS3Client:
         except ClientError as error:
             # return none if key does not exist
             if error.response["Error"]["Code"] == "NoSuchKey":
-                log.warn(f"Object with URI '{uri}' does not exist!")
+                log.warning(f"Object with URI '{uri}' does not exist!")
                 return None
             log.error(
                 f"Unexpected error occurred getting object from S3 '{uri}'!",

--- a/src/news/bucket.py
+++ b/src/news/bucket.py
@@ -32,12 +32,12 @@ class NewsSummariesBucket:
 
     def put_news_summary(self, stock: str, summary: str) -> None:
         log.info("Dumping news summary to S3")
-        key = NewsSummariesBucket._get_summary_key(stock)
+        key = NewsSummariesBucket._get_summary_key(stock, dt.now())
         self.client.put_object(self.bucket, key, summary)
 
     def get_news_summary(self, stock: str) -> str | None:
         log.info("Getting news summary from S3")
-        key = NewsSummariesBucket._get_summary_key(stock)
+        key = NewsSummariesBucket._get_summary_key(stock, dt.now())
         return self.client.get_object(self.bucket, key)
 
     @staticmethod
@@ -45,11 +45,11 @@ class NewsSummariesBucket:
         return NewsSummariesBucket.BUCKET.format(domain=domain.value)
 
     @staticmethod
-    def _get_summary_key(stock: str) -> str:
+    def _get_summary_key(stock: str, timestamp: dt) -> str:
         return NewsSummariesBucket.SUMMARY_KEY.format(
             summaries_dir=NewsSummariesBucket.SUMMARIES_DIR,
             stock=stock.upper(),
-            date=NewsSummariesBucket._get_datestamp(dt.now()),
+            date=NewsSummariesBucket._get_datestamp(timestamp),
         )
 
     @staticmethod

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -207,11 +207,18 @@ def s3_client() -> S3Client:
             Key="templates/default/template.jinja",
             Body=open("./templates/default/template.jinja", "rb").read(),
         )
+        mock_s3.create_bucket(Bucket="walterai-news-summaries-unittest")
+        now = dt.now()
+        mock_s3.put_object(
+            Bucket="walterai-news-summaries-unittest",
+            Key=f"summaries/MSFT/{now.strftime('y=%Y/m=%m/d=%d')}/summary.html",
+            Body="news summary",
+        )
         yield mock_s3
 
 
 @pytest.fixture
-def ses_client() -> S3Client:
+def ses_client() -> SESClient:
     with mock_aws():
         mock_ses = boto3.client("ses", region_name=AWS_REGION)
         yield mock_ses

--- a/tst/news/test_news_bucket.py
+++ b/tst/news/test_news_bucket.py
@@ -1,0 +1,113 @@
+import pytest
+
+from src.aws.s3.client import WalterS3Client
+from src.environment import Domain
+from src.news.bucket import NewsSummariesBucket
+import datetime as dt
+
+##########################
+# NEWS SUMMARIES BUCKETS #
+##########################
+
+NEWS_SUMMARIES_BUCKET_TEST = "walterai-news-summaries-unittest"
+NEWS_SUMMARIES_BUCKET_DEV = "walterai-news-summaries-dev"
+NEWS_SUMMARIES_BUCKET_PREPROD = "walterai-news-summaries-preprod"
+NEWS_SUMMARIES_BUCKET_PROD = "walterai-news-summaries-prod"
+
+##################
+# NEWS SUMMARIES #
+##################
+
+MSFT_SUMMARY_KEY = "summaries/MSFT/y=2025/m=01/d=01/summary.html"
+ABNB_SUMMARY_KEY = "summaries/ABNB/y=2025/m=01/d=01/summary.html"
+
+################################
+# NEWS SUMMARIES BUCKET CLIENT #
+################################
+
+
+@pytest.fixture
+def news_summaries_bucket(walter_s3: WalterS3Client) -> NewsSummariesBucket:
+    return NewsSummariesBucket(walter_s3, Domain.TESTING)
+
+
+##############
+# UNIT TESTS #
+##############
+
+
+def test_put_summary(
+    news_summaries_bucket: NewsSummariesBucket, walter_s3: WalterS3Client
+) -> None:
+    stock = "ABNB"
+    now = dt.datetime.now()
+    assert (
+        walter_s3.get_object(
+            NEWS_SUMMARIES_BUCKET_TEST,
+            f"summaries/{stock}/{now.strftime('y=%Y/m=%m/d=%d')}/summary.html",
+        )
+        is None
+    )
+    news_summaries_bucket.put_news_summary(stock, "summary")
+    assert (
+        walter_s3.get_object(
+            NEWS_SUMMARIES_BUCKET_TEST,
+            f"summaries/{stock}/{now.strftime('y=%Y/m=%m/d=%d')}/summary.html",
+        )
+        is not None
+    )
+
+
+def test_get_summary_does_exist(
+    news_summaries_bucket: NewsSummariesBucket, walter_s3: WalterS3Client
+) -> None:
+    stock = "MSFT"
+    now = dt.datetime.now()
+    assert (
+        walter_s3.get_object(
+            NEWS_SUMMARIES_BUCKET_TEST,
+            f"summaries/{stock}/{now.strftime('y=%Y/m=%m/d=%d')}/summary.html",
+        )
+        is not None
+    )
+    assert news_summaries_bucket.get_news_summary("MSFT") is not None
+
+
+def test_get_summary_does_not_exist(
+    news_summaries_bucket: NewsSummariesBucket, walter_s3: WalterS3Client
+) -> None:
+    stock = "ABNB"
+    now = dt.datetime.now()
+    assert (
+        walter_s3.get_object(
+            NEWS_SUMMARIES_BUCKET_TEST,
+            f"summaries/{stock}/{now.strftime('y=%Y/m=%m/d=%d')}/summary.html",
+        )
+        is None
+    )
+    assert news_summaries_bucket.get_news_summary(stock) is None
+
+
+def test_get_news_summaries_bucket_name() -> None:
+    assert (
+        NewsSummariesBucket._get_bucket_name(Domain.TESTING)
+        == NEWS_SUMMARIES_BUCKET_TEST
+    )
+    assert (
+        NewsSummariesBucket._get_bucket_name(Domain.DEVELOPMENT)
+        == NEWS_SUMMARIES_BUCKET_DEV
+    )
+    assert (
+        NewsSummariesBucket._get_bucket_name(Domain.STAGING)
+        == NEWS_SUMMARIES_BUCKET_PREPROD
+    )
+    assert (
+        NewsSummariesBucket._get_bucket_name(Domain.PRODUCTION)
+        == NEWS_SUMMARIES_BUCKET_PROD
+    )
+
+
+def test_get_news_summary_key() -> None:
+    datestamp = dt.datetime(year=2025, month=1, day=1)
+    assert NewsSummariesBucket._get_summary_key("MSFT", datestamp) == MSFT_SUMMARY_KEY
+    assert NewsSummariesBucket._get_summary_key("ABNB", datestamp) == ABNB_SUMMARY_KEY


### PR DESCRIPTION
This PR adds unit tests for the news summaries bucket client to test getting/putting news summaries to/from S3.