### PR TITLE
feat: Add user subscription status to GetUser API response

### DIFF
--- a/src/api/get_user.py
+++ b/src/api/get_user.py
@@ -59,6 +59,7 @@ class GetUser(WalterAPIMethod):
                 "email": authenticated_email,
                 "username": user.username,
                 "verified": user.verified,
+                "subscribed": user.subscribed,
             },
         )
 

--- a/tst/api/test_get_user.py
+++ b/tst/api/test_get_user.py
@@ -26,7 +26,12 @@ def test_get_user(get_user_api: GetUser, jwt_walter: str) -> None:
         status_code=HTTPStatus.OK,
         status=Status.SUCCESS,
         message="Successfully retrieved user!",
-        data={"email": "walter@gmail.com", "username": "walter", "verified": True},
+        data={
+            "email": "walter@gmail.com",
+            "username": "walter",
+            "verified": True,
+            "subscribed": True,
+        },
     )
     assert expected_response == get_user_api.invoke(event)
 


### PR DESCRIPTION
This PR adds the user subscription status to the `GetUser` API response so that WalterFrontend can alert the user on whether or not they're subscribed.

This will be a mechanism to ensure that users are encourage to subscribed to the newsletter.