### PR TITLE
feat: Add NewsSummaries queue for async news summary processing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4,6 +4,7 @@ import typer
 
 from src.newsletters.publish import add_newsletter_to_queue
 from src.utils.log import Logger
+from src.workflows.add_news_summary_requests import add_news_summary_requests_workflow
 from tst.api.utils import (
     get_auth_user_event,
     get_create_user_event,
@@ -192,9 +193,9 @@ def search_stocks(stock: str = None) -> None:
     log.info(f"Walter CLI: Response:\n{parse_response(response)}")
 
 
-###########################
-# WALTER SEND NEWSLETTERS #
-###########################
+############################
+# WALTER BACKEND WORKFLOWS #
+############################
 
 
 @app.command()
@@ -203,9 +204,10 @@ def send_newsletters():
     add_newsletter_to_queue({}, CONTEXT)
 
 
-##################
-# WALTER BACKEND #
-##################
+@app.command()
+def generate_news_summaries() -> None:
+    log.info("WalterCLI: Generating news summaries...")
+    add_news_summary_requests_workflow({}, CONTEXT)
 
 
 @app.command()

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -1440,6 +1440,40 @@ Resources:
         Variables:
           DOMAIN: DEVELOPMENT
 
+  WalterWorkflowAddNewsSummaryRequestsAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Ref WalterWorkflowAddNewsSummaryRequests
+      FunctionVersion: $LATEST
+      Name: !Sub "WalterWorkflow-AddNewsSummaryRequests-${AppEnvironment}"
+
+  WalterWorkflowAddNewsSummaryRequests:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "WalterWorkflow-AddNewsSummaryRequests-${AppEnvironment}"
+      Description: !Sub "WalterWorkflow: AddNewsSummaryRequests - Scan WalterDB and add news summary requests for all stocks (${AppEnvironment})"
+      Handler: walter.add_news_summary_requests_entrypoint
+      Role: !GetAtt WalterWorkflowAddNewsSummaryRequestsRole.Arn
+      Code:
+        S3Bucket: walter-backend-src
+        S3Key: walter-backend.zip
+      Timeout: 60
+      Runtime: python3.11
+      Architectures:
+        - "arm64"
+      Layers:
+        - !Join
+          - ""
+          - - "arn:aws:lambda:"
+            - !Ref "AWS::Region"
+            - ":"
+            - !Ref "AWS::AccountId"
+            - ":layer:"
+            - "WalterAILambdaLayer:29"
+      Environment:
+        Variables:
+          DOMAIN: DEVELOPMENT
+
   WalterBackendAlias:
     Type: AWS::Lambda::Alias
     Properties:
@@ -1564,6 +1598,23 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 
+  WalterWorkflowAddNewsSummaryRequestsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "WalterWorkflow-AddNewsSummaryRequestsRole-${AppEnvironment}"
+      Description: !Sub "WalterWorkflow-AddNewsSummaryRequests-${AppEnvironment} role to add news summary requests to queue for asynchronous processing."
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
   WalterBackendRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1648,6 +1699,23 @@ Resources:
         - !Ref WalterNewslettersRole
         - !Ref WalterBackendRole
 
+  NewsSummariesQueueAccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub "NewsSummariesQueueAccessPolicy-${AppEnvironment}"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action:
+              - "sqs:ReceiveMessage"
+              - "sqs:DeleteMessage"
+              - "sqs:GetQueueAttributes"
+              - "sqs:SendMessage"
+            Resource: !GetAtt NewsSummariesQueue.Arn
+      Roles:
+        - !Ref WalterWorkflowAddNewsSummaryRequestsRole
+
   SecretsManagerAccessPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -1719,6 +1787,7 @@ Resources:
         - !Ref WalterAPIRole
         - !Ref WalterNewslettersRole
         - !Ref WalterBackendRole
+        - !Ref WalterWorkflowAddNewsSummaryRequestsRole
 
   SimpleEmailSerivceAccessPolicy:
     Type: AWS::IAM::Policy
@@ -1756,6 +1825,7 @@ Resources:
       Roles:
         - !Ref WalterAPIRole
         - !Ref WalterBackendRole
+        - !Ref WalterWorkflowAddNewsSummaryRequestsRole
 
   TemplatesBucketAccessPolicy:
     Type: AWS::IAM::Policy
@@ -1934,6 +2004,13 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub "NewslettersQueue-${AppEnvironment}"
+      SqsManagedSseEnabled: true
+      VisibilityTimeout: 3600
+
+  NewsSummariesQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "NewsSummariesQueue-${AppEnvironment}"
       SqsManagedSseEnabled: true
       VisibilityTimeout: 3600
 

--- a/scripts/update-lambdas.sh
+++ b/scripts/update-lambdas.sh
@@ -34,5 +34,7 @@ echo Updating WalterAPI Auth source code with artifact from S3 \
 && aws lambda update-function-code --function-name WalterAPI-SearchStocks-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
 && echo Updating WalterNewsletters source code with artifact from S3 \
 && aws lambda update-function-code --function-name WalterNewsletters-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
+&& echo Updating WalterWorkflow AddNewsSummaryRequests source code with artifact from S3 \
+&& aws lambda update-function-code --function-name WalterWorkflow-AddNewsSummaryRequests-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip \
 && echo Updating WalterBackend source code with artifact from S3 \
 && aws lambda update-function-code --function-name WalterBackend-dev --s3-bucket walter-backend-src --s3-key walter-backend.zip

--- a/src/clients.py
+++ b/src/clients.py
@@ -17,6 +17,7 @@ from src.database.client import WalterDB
 from src.environment import get_domain
 from src.events.parser import WalterEventParser
 from src.news.bucket import NewsSummariesBucket
+from src.news.queue import NewsSummariesQueue
 from src.newsletters.client import NewslettersBucket
 from src.newsletters.queue import NewslettersQueue
 from src.stocks.alphavantage.client import AlphaVantageClient
@@ -57,6 +58,9 @@ walter_cw = WalterCloudWatchClient(
 walter_ses = WalterSESClient(
     client=boto3.client("ses", region_name=AWS_REGION), domain=DOMAIN
 )
+walter_sqs = WalterSQSClient(
+    client=boto3.client("sqs", region_name=AWS_REGION), domain=DOMAIN
+)
 
 ###########
 # BUCKETS #
@@ -90,11 +94,13 @@ walter_authenticator = WalterAuthenticator(walter_sm=walter_sm)
 # NEWSLETTERS QUEUE #
 #####################
 
-newsletters_queue = NewslettersQueue(
-    client=WalterSQSClient(
-        client=boto3.client("sqs", region_name=AWS_REGION), domain=DOMAIN
-    )
-)
+newsletters_queue = NewslettersQueue(client=walter_sqs)
+
+########################
+# NEWS SUMMARIES QUEUE #
+########################
+
+news_summaries_queue = NewsSummariesQueue(client=walter_sqs)
 
 #############
 # WALTER DB #

--- a/src/events/models.py
+++ b/src/events/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CreateNewsletterAndSendEvent:
+    """
+    CreateNewsletterAndSendEvent
+
+    This event is consumed by WalterBackend via a SQS queue and is used
+    to generate and send a newsletter to a user with the given email.
+    """
+
+    receipt_handle: str
+    email: str

--- a/src/events/parser.py
+++ b/src/events/parser.py
@@ -1,22 +1,10 @@
 import json
 from dataclasses import dataclass
 
+from src.events.models import CreateNewsletterAndSendEvent
 from src.utils.log import Logger
 
 log = Logger(__name__).get_logger()
-
-
-@dataclass(frozen=True)
-class CreateNewsletterAndSendEvent:
-    """
-    CreateNewsletterAndSendEvent
-
-    This event is consumed by WalterBackend via a SQS queue and is used
-    to generate and send a newsletter to a user with the given email.
-    """
-
-    receipt_handle: str
-    email: str
 
 
 @dataclass

--- a/src/news/queue.py
+++ b/src/news/queue.py
@@ -1,0 +1,93 @@
+import datetime as dt
+import json
+import os
+from dataclasses import dataclass
+
+from src.aws.sqs.client import WalterSQSClient
+from src.utils.log import Logger
+
+log = Logger(__name__).get_logger()
+
+##########
+# MODELS #
+##########
+
+
+@dataclass
+class NewsSummaryRequest:
+    datestamp: dt.datetime
+    stock: str
+
+    def __post_init__(self) -> None:
+        self._verify_datestamp()
+
+    def to_message(self) -> dict:
+        return self.__dict__()
+
+    def _verify_datestamp(self) -> None:
+        truncated_datestamp = self.datestamp.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        if self.datestamp != truncated_datestamp:
+            raise ValueError(
+                f"Cannot create NewsSummaryRequest! Datestamp not truncated to a date: '{truncated_datestamp}'"
+            )
+
+    def __dict__(self) -> dict:
+        return {
+            "datestamp": self.datestamp.strftime("%Y-%m-%d"),
+            "stock": self.stock,
+        }
+
+    def __str__(self) -> str:
+        return json.dumps(self.__dict__(), indent=4)
+
+
+##########
+# CLIENT #
+##########
+
+
+@dataclass
+class NewsSummariesQueue:
+    """
+    NewsSummariesQueue
+    """
+
+    QUEUE_URL_FORMAT = (
+        "https://sqs.{region}.amazonaws.com/{account_id}/NewsSummariesQueue-{domain}"
+    )
+
+    client: WalterSQSClient
+
+    queue_url: str = None  # set during post init
+
+    def __post_init__(self) -> None:
+        self.queue_url = self._get_queue_url()
+        log.debug(f"Creating NewsSummaryQueue with queue URL: '{self.queue_url}'")
+
+    def add_news_summary_request(self, request: NewsSummaryRequest) -> str:
+        log.info(f"Adding news summary request to queue:\n{request}")
+        message_id = self.client.send_message(
+            queue_url=self.queue_url, message=request.to_message()
+        )
+        log.info(f"Added news summary request to queue with message ID: {message_id}")
+        return message_id
+
+    def delete_news_summary_request(self, receipt_handle: str) -> None:
+        log.info(
+            f"Deleting news summary request with the following receipt handle: {receipt_handle}"
+        )
+        self.client.delete_event(
+            queue_url=self.queue_url, receipt_handle=receipt_handle
+        )
+        log.info("Successfully deleted news summary request from queue")
+
+    def _get_queue_url(self) -> str:
+        return NewsSummariesQueue.QUEUE_URL_FORMAT.format(
+            region=self.client.client.meta.region_name,
+            account_id=os.getenv(
+                "AWS_ACCOUNT_ID", "010526272437"
+            ),  # TODO: Fix me! AWS account IDs aren't meant to be private but get rid of it
+            domain=self.client.domain.value,
+        )

--- a/src/workflows/add_news_summary_requests.py
+++ b/src/workflows/add_news_summary_requests.py
@@ -1,0 +1,35 @@
+import datetime as dt
+import json
+
+from src.clients import walter_db, news_summaries_queue
+from src.news.queue import NewsSummaryRequest
+from src.utils.log import Logger
+
+log = Logger(__name__).get_logger()
+
+
+def add_news_summary_requests_workflow(event, context) -> dict:
+    log.info("WalterWorkflow: Add News Summary Requests")
+
+    log.info(
+        "Scanning WalterDB Stocks table for all stocks to generate news summaries..."
+    )
+    for stock in walter_db.get_all_stocks():
+        log.info(
+            f"Add news summary request for stock '{stock.symbol.upper()}' to queue"
+        )
+        news_summaries_queue.add_news_summary_request(
+            NewsSummaryRequest(
+                datestamp=dt.datetime.now().replace(
+                    hour=0, minute=0, second=0, microsecond=0
+                ),
+                stock=stock.symbol.upper(),
+            )
+        )
+    log.info(
+        "Successfully scanned WalterDB Stocks table and submitted news summary requests for all stocks!"
+    )
+    return {
+        "statusCode": 200,
+        "body": json.dumps("WalterWorkflow: Add News Summary Requests"),
+    }

--- a/walter.py
+++ b/walter.py
@@ -30,6 +30,9 @@ from src.clients import (
     walter_ai,
 )
 from src.newsletters.publish import add_newsletter_to_queue
+from src.workflows.add_news_summary_requests import (
+    add_news_summary_requests_workflow,
+)
 
 
 ##############
@@ -142,21 +145,22 @@ def unsubscribe_entrypoint(event, context) -> dict:
 
 
 def search_stocks_entrypoint(event, context) -> dict:
-    return SearchStocks(walter_authenticator, walter_cw, walter_stocks_api).invoke(event)
+    return SearchStocks(walter_authenticator, walter_cw, walter_stocks_api).invoke(
+        event
+    )
 
 
-######################
-# WALTER NEWSLETTERS #
-######################
+############################
+# WALTER BACKEND WORKFLOWS #
+############################
 
 
 def add_newsletter_to_queue_entrypoint(event, context) -> dict:
     return add_newsletter_to_queue(event, context)
 
 
-##################
-# WALTER BACKEND #
-##################
+def add_news_summary_requests_entrypoint(event, context) -> dict:
+    return add_news_summary_requests_workflow(event, context)
 
 
 def create_newsletter_and_send_entrypoint(event, context) -> dict:


### PR DESCRIPTION
This PR adds a `NewSummaries` queue that Walter publishes stock messages to for asynchronous news summary processing.

Right now, users experience bad `GetStockNewsSummary` API response latency due to AlphaVantage and Bedrock API calls. 

This PR is the start of adding an asynchronous workflow so that Walter can compute stock news summaries before users request them via WalterFrontend to improve API response times.