### PR TITLE
fix: Store user emails as lowercase for case-insensitive email matching

### DIFF
--- a/src/api/auth_user.py
+++ b/src/api/auth_user.py
@@ -22,7 +22,7 @@ class AuthUser(WalterAPIMethod):
 
     Validate the given password against the stored hash for the given user email.
     If the password is correct, return a unique identity token for the user to
-    utilize to make authenticated requests.
+    use to make authenticated requests.
     """
 
     API_NAME = "AuthUser"
@@ -67,7 +67,7 @@ class AuthUser(WalterAPIMethod):
         body = json.loads(event["body"])
 
         # verify email is valid
-        email = body["email"]
+        email = body["email"].lower()
         if not is_valid_email(email):
             raise InvalidEmail("Invalid email!")
 
@@ -75,7 +75,7 @@ class AuthUser(WalterAPIMethod):
         return False
 
     def _verify_user_exists(self, event: dict) -> User:
-        email = json.loads(event["body"])["email"]
+        email = json.loads(event["body"])["email"].lower()
         log.info(f"Verifying user exists with email '{email}'")
         user = self.walter_db.get_user(email)
         if user is None:

--- a/tst/api/test_create_user.py
+++ b/tst/api/test_create_user.py
@@ -41,6 +41,23 @@ def test_create_user(create_user_api: CreateUser) -> None:
     assert expected_response == create_user_api.invoke(event)
 
 
+def test_create_user_success_uppercase_email_stored_as_lowercase(
+    create_user_api: CreateUser, walter_db: WalterDB
+) -> None:
+    event = get_create_user_event(
+        email="JIMMY@gmail.com", username="jimmy", password="jimmy"
+    )
+    expected_response = get_expected_response(
+        api_name=create_user_api.API_NAME,
+        status_code=HTTPStatus.CREATED,
+        status=Status.SUCCESS,
+        message="User created!",
+    )
+    assert expected_response == create_user_api.invoke(event)
+    user = walter_db.get_user("jimmy@gmail.com")
+    assert user.email == "jimmy@gmail.com"
+
+
 def test_create_user_failure_invalid_email(create_user_api: CreateUser) -> None:
     event = get_create_user_event(email="jim", username="jim", password="jim")
     expected_response = get_expected_response(


### PR DESCRIPTION
Another bug found from pre-pre-beta testing with friends.

User email's should be stored in WalterDB as lowercase so that users can be queried by their email address in a case-insensitive manner. 

This is important because sometimes browsers detect a form and then automatically uppercase the string. If that form happens to be the Walter login form then the user would mistakenly get a `User not found!` error message returned from `WalterBackend` which is pretty confusing.

This is a great way to immediately lose a new user so important to fix this behavior. 