### PR TITLE
fix: Stop the double Lambda logs

### DIFF
--- a/src/utils/log.py
+++ b/src/utils/log.py
@@ -32,7 +32,7 @@ class Logger:
     def get_logger(self) -> Logger:
         logger = getLogger(self.name)
         logger.setLevel(self.log_level)
-        logger.addHandler(self._get_console_handler())
+        # logger.addHandler(self._get_console_handler())
         # logger.addHandler(self._get_file_handler(filename=LOG_FILE))
         coloredlogs.install(
             fmt="%(asctime)s :: %(levelname)s :: %(name)s :: %(message)s",


### PR DESCRIPTION
All Lambda logs used to double print and it was so annoying...

Seems to just be a bug with the custom logger I have shared between projects for far too long.

I just uncommented the extra handler... Don't want to actually spend the time to refactor the class and make it good... yet.