### PR TITLE
feat: Add user verified and subscribed metrics

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -102,6 +102,14 @@ def add_stock(token: str = None, stock: str = None, quantity: float = None) -> N
 
 
 @app.command()
+def get_stock(symbol: str = None) -> None:
+    log.info("WalterCLI: GetStock")
+    event = get_get_stock_event(symbol)
+    response = get_stock_entrypoint(event, CONTEXT)
+    log.info(f"WalterCLI: GetStock Response:\n{parse_response(response)}")
+
+
+@app.command()
 def get_prices(stock: str = None) -> None:
     log.info("Walter CLI: Getting prices...")
     event = get_get_prices_event(stock)
@@ -162,14 +170,6 @@ def send_change_password_email(email: str = None) -> None:
     log.info("Walter CLI: Sending change password email...")
     event = get_send_change_password_email_event(email)
     response = send_change_password_email_entrypoint(event, CONTEXT)
-    log.info(f"Walter CLI: Response:\n{parse_response(response)}")
-
-
-@app.command()
-def get_stock(symbol: str = None) -> None:
-    log.info("Walter CLI: Getting stock...")
-    event = get_get_stock_event(symbol)
-    response = get_stock_entrypoint(event, CONTEXT)
     log.info(f"Walter CLI: Response:\n{parse_response(response)}")
 
 

--- a/src/api/common/methods.py
+++ b/src/api/common/methods.py
@@ -61,9 +61,8 @@ class WalterAPIMethod(ABC):
         Returns:
             The API response.
         """
-        log.info(
-            f"Invoking '{self.api_name}' API with event:\n{json.dumps(event, indent=4)}"
-        )
+        log.info(f"Invoking '{self.api_name}' API")
+        log.debug(f"Event:\n{json.dumps(event, indent=4)}")
 
         response = None
         try:
@@ -218,6 +217,7 @@ class WalterAPIMethod(ABC):
         Args:
             response: The API response object.
         """
+        log.info(f"Emitting metrics for '{self.api_name}' API")
         success = response["statusCode"] == HTTPStatus.OK.value
         self.metrics.emit_metric(
             self._get_success_count_metric_name(), 1 if success else 0

--- a/src/aws/dynamodb/client.py
+++ b/src/aws/dynamodb/client.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 from typing import List
 
@@ -36,7 +37,7 @@ class WalterDDBClient:
         Returns:
             None.
         """
-        log.debug(f"Adding item to table '{table}':\n{item}")
+        log.debug(f"Adding item to table '{table}':\n{json.dumps(item, indent=4)}")
         try:
             self.client.put_item(TableName=table, Item=item)
         except ClientError as error:
@@ -76,7 +77,9 @@ class WalterDDBClient:
         Returns:
             The DDB item of the item with the given primary key.
         """
-        log.debug(f"Getting item from table '{table}' with key:\n{key}")
+        log.debug(
+            f"Getting item from table '{table}' with key:\n{json.dumps(key, indent=4)}"
+        )
         try:
             return self.client.get_item(TableName=table, Key=key)["Item"]
         except ClientError as clientError:

--- a/src/database/stocks/table.py
+++ b/src/database/stocks/table.py
@@ -44,7 +44,7 @@ class StocksTable:
         Returns:
             The Stock object if it exists in the Stocks table.
         """
-        log.info(f"Getting stock with symbol '{symbol}' from table '{self.table}'")
+        log.info(f"Getting stock '{symbol}' from Stocks table")
         key = StocksTable._get_stock_key(symbol)
         item = self.ddb.get_item(self.table, key)
         return StocksTable._get_stock_from_ddb_item(item) if item is not None else None
@@ -75,9 +75,8 @@ class StocksTable:
         Returns:
             None.
         """
-        log.info(
-            f"Putting stock to table '{self.table}':\n{json.dumps(stock.to_dict(), indent=4)}"
-        )
+        log.info(f"Putting stock '{stock.symbol}' to Stocks table")
+        log.debug(f"Stock:\n{json.dumps(stock.to_dict(), indent=4)}")
         self.ddb.put_item(self.table, stock.to_ddb_item())
 
     @staticmethod

--- a/src/stocks/alphavantage/client.py
+++ b/src/stocks/alphavantage/client.py
@@ -77,9 +77,8 @@ class AlphaVantageClient:
             official_site=response["OfficialSite"],
             address=response["Address"],
         )
-        log.info(
-            f"Returned company overview for '{symbol}':\n{json.dumps(overview.to_dict(), indent=4)}"
-        )
+        log.info(f"Returned company overview for '{symbol}'")
+        log.debug(f"CompanyOverview:\n{json.dumps(overview.to_dict(), indent=4)}")
 
         return overview
 

--- a/src/workflows/add_news_summary_requests.py
+++ b/src/workflows/add_news_summary_requests.py
@@ -1,7 +1,9 @@
 import datetime as dt
 import json
+from typing import List
 
 from src.clients import walter_db, news_summaries_queue, walter_cw
+from src.database.stocks.models import Stock
 from src.news.queue import NewsSummaryRequest
 from src.utils.log import Logger
 
@@ -13,6 +15,12 @@ log = Logger(__name__).get_logger()
 
 METRICS_NUMBER_OF_STOCKS = "NumberOfStocks"
 """(str): The total number of unique stocks analyzed by WalterDB."""
+
+
+def emit_metrics(stocks: List[Stock]) -> None:
+    log.info("Emitting total number of stocks metric...")
+    walter_cw.emit_metric(metric_name=METRICS_NUMBER_OF_STOCKS, count=len(stocks))
+
 
 ############
 # WORKFLOW #
@@ -47,8 +55,8 @@ def add_news_summary_requests_workflow(event, context) -> dict:
         "Successfully scanned WalterDB Stocks table and submitted news summary requests for all stocks!"
     )
 
-    log.info("Emitting total number of stocks metric...")
-    walter_cw.emit_metric(metric_name=METRICS_NUMBER_OF_STOCKS, count=len(stocks))
+    # emit metrics about the total number of stocks in db
+    emit_metrics(stocks)
 
     return {
         "statusCode": 200,

--- a/src/workflows/add_newsletter_requests.py
+++ b/src/workflows/add_newsletter_requests.py
@@ -1,6 +1,8 @@
 import json
+from typing import List
 
 from src.clients import walter_db, newsletters_queue, walter_cw
+from src.database.users.models import User
 from src.newsletters.queue import NewsletterRequest
 
 from src.utils.log import Logger
@@ -13,6 +15,40 @@ log = Logger(__name__).get_logger()
 
 METRICS_NUMBER_OF_USERS = "NumberOfUsers"
 """(str): The total number of Walter users (all users count, even unsubscribed/unverified users)."""
+
+METRICS_NUMBER_OF_VERIFIED_USERS = "NumberOfVerifiedUsers"
+"""(str): The total number of verified Walter users."""
+
+METRICS_NUMBER_OF_UNVERIFIED_USERS = "NumberOfUnverifiedUsers"
+"""(str): The total number of unverified Walter users."""
+
+METRICS_NUMBER_OF_SUBSCRIBED_USERS = "NumberOfSubscribedUsers"
+"""(str): The total number of subscribed Walter users."""
+
+METRICS_NUMBER_OF_UNSUBSCRIBED_USERS = "NumberOfUnsubscribedUsers"
+"""(str): The total number of unsubscribed Walter users."""
+
+
+def emit_metrics(users: List[User]) -> None:
+    log.info("Emitting metrics about the total number of users...")
+    verified_users = [user for user in users if user.verified]
+    unverified_users = [user for user in users if not user.verified]
+    subscribed_users = [user for user in users if user.subscribed]
+    unsubscribed_users = [user for user in users if not user.subscribed]
+    walter_cw.emit_metric(metric_name=METRICS_NUMBER_OF_USERS, count=len(users))
+    walter_cw.emit_metric(
+        metric_name=METRICS_NUMBER_OF_VERIFIED_USERS, count=len(verified_users)
+    )
+    walter_cw.emit_metric(
+        metric_name=METRICS_NUMBER_OF_UNVERIFIED_USERS, count=len(unverified_users)
+    )
+    walter_cw.emit_metric(
+        metric_name=METRICS_NUMBER_OF_SUBSCRIBED_USERS, count=len(subscribed_users)
+    )
+    walter_cw.emit_metric(
+        metric_name=METRICS_NUMBER_OF_UNSUBSCRIBED_USERS, count=len(unsubscribed_users)
+    )
+
 
 ############
 # WORKFLOW #
@@ -51,8 +87,7 @@ def add_newsletter_requests_workflow(event, context) -> dict:
         newsletters_queue.add_newsletter_request(request)
 
     # emit metrics about the total number of users
-    log.info("Emitting metrics about the total number of users...")
-    walter_cw.emit_metric(metric_name=METRICS_NUMBER_OF_USERS, count=len(users))
+    emit_metrics(users)
 
     return {
         "statusCode": 200,


### PR DESCRIPTION
This PR adds more user metrics so that the executive dashboard can differentiate between verified/subscribed users... pretty cool!

Also, AWS has plenty of great metrics already, a lot of these metrics were derived from the underlying service.

Need to eventually add metrics on the number of articles parsed and summarized by WalterDB

<img width="1727" alt="Screenshot 2025-02-13 at 12 51 04 AM" src="https://github.com/user-attachments/assets/10e4e276-f38a-4798-ab5f-bfc3d5f7be97" />
