### PR TITLE
feat: Dump news summary generation metadata to archive

### DIFF
--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -1423,7 +1423,7 @@ Resources:
       Code:
         S3Bucket: walter-backend-src
         S3Key: walter-backend.zip
-      Timeout: 60
+      Timeout: 300
       Runtime: python3.11
       Architectures:
         - "arm64"
@@ -1457,7 +1457,7 @@ Resources:
       Code:
         S3Bucket: walter-backend-src
         S3Key: walter-backend.zip
-      Timeout: 60
+      Timeout: 300
       Runtime: python3.11
       Architectures:
         - "arm64"
@@ -1491,7 +1491,7 @@ Resources:
       Code:
         S3Bucket: walter-backend-src
         S3Key: walter-backend.zip
-      Timeout: 60
+      Timeout: 300
       Runtime: python3.11
       MemorySize: 512
       Architectures:
@@ -1534,7 +1534,7 @@ Resources:
         Code:
           S3Bucket: walter-backend-src
           S3Key: walter-backend.zip
-        Timeout: 60
+        Timeout: 300
         Runtime: python3.11
         MemorySize: 512
         Architectures:

--- a/src/clients.py
+++ b/src/clients.py
@@ -22,6 +22,7 @@ from src.newsletters.queue import NewslettersQueue
 from src.stocks.alphavantage.client import AlphaVantageClient
 from src.stocks.client import WalterStocksAPI
 from src.stocks.polygon.client import PolygonClient
+from src.summaries.client import WalterNewsSummaryClient
 from src.templates.bucket import TemplatesBucket
 from src.templates.engine import TemplatesEngine
 from src.utils.log import Logger
@@ -141,4 +142,12 @@ walter_ai = WalterAI(
         bedrock=boto3.client("bedrock", region_name=AWS_REGION),
         bedrock_runtime=boto3.client("bedrock-runtime", region_name=AWS_REGION),
     ),
+)
+
+##############################
+# WALTER NEWS SUMMARY CLIENT #
+##############################
+
+walter_news_summary_client = WalterNewsSummaryClient(
+    walter_stock_api=walter_stocks_api, walter_ai=walter_ai
 )

--- a/src/news/bucket.py
+++ b/src/news/bucket.py
@@ -1,10 +1,11 @@
+import json
 import re
 from dataclasses import dataclass
 from datetime import datetime as dt
 
 from src.aws.s3.client import WalterS3Client
 from src.environment import Domain
-from src.news.models import NewsSummary
+from src.summaries.models import NewsSummary
 from src.utils.log import Logger
 
 log = Logger(__name__).get_logger()
@@ -23,6 +24,7 @@ class NewsSummariesBucket:
 
     SUMMARIES_DIR = "summaries"
     SUMMARIES_PREFIX = "{summaries_dir}/{stock}"
+    METADATA_KEY = "{summaries_dir}/{stock}/{date}/metadata.json"
     SUMMARY_KEY = "{summaries_dir}/{stock}/{date}/summary.html"
 
     client: WalterS3Client
@@ -36,14 +38,26 @@ class NewsSummariesBucket:
             f"Creating '{self.domain.value}' NewsSummariesBucket S3 client with bucket '{self.bucket}'"
         )
 
-    def put_news_summary(self, stock: str, summary: str, date: dt = TODAY) -> None:
-        log.info("Dumping news summary to S3")
-        key = NewsSummariesBucket._get_summary_key(stock, date)
-        return self.client.put_object(self.bucket, key, summary)
+    def put_news_summary(self, news: NewsSummary) -> str:
+        log.info(
+            f"Putting news summary to archive for stock '{news.stock}' with date: '{news.datestamp.strftime('%Y-%m-%d')}'"
+        )
+
+        log.debug(
+            f"Putting news summary metadata to archive for stock '{news.stock}'..."
+        )
+        metadata = json.dumps(news.get_metadata(), indent=4)
+        metadata_key = NewsSummariesBucket._get_metadata_key(news.stock, news.datestamp)
+        self.client.put_object(self.bucket, metadata_key, metadata)
+
+        log.debug(f"Putting news summary to archive for stock '{news.stock}'...")
+        summary = news.summary
+        summary_key = NewsSummariesBucket._get_summary_key(news.stock, news.datestamp)
+        return self.client.put_object(self.bucket, summary_key, summary)
 
     def get_news_summary(self, stock: str, date: dt = TODAY) -> str | None:
         log.info(
-            f"Getting news summary from archive for stock '{stock}' with date: '{date.isoformat()}'"
+            f"Getting news summary from archive for stock '{stock}' with date: '{date.strftime('%Y-%m-%d')}'...'"
         )
         key = NewsSummariesBucket._get_summary_key(stock, date)
         return self.client.get_object(self.bucket, key)
@@ -53,7 +67,7 @@ class NewsSummariesBucket:
         prefix = NewsSummariesBucket._get_summaries_prefix(stock)
         prefixes = self.client.list_objects(self.bucket, prefix)
 
-        # ensure summaries exist for given stock
+        # ensure summaries exist for given stockpi
         if len(prefixes) == 0:
             log.info("No summaries found for stock '{stock}'!")
             return None
@@ -62,6 +76,7 @@ class NewsSummariesBucket:
 
         return NewsSummary(
             stock=stock.upper(),
+            datestamp=dt.today(),
             model_name="TODO",
             articles=[],
             summary=self.remove_non_alphanumeric(summary),
@@ -72,11 +87,19 @@ class NewsSummariesBucket:
         return NewsSummariesBucket.BUCKET.format(domain=domain.value)
 
     @staticmethod
-    def _get_summary_key(stock: str, timestamp: dt) -> str:
+    def _get_metadata_key(stock: str, datestamp: dt):
+        return NewsSummariesBucket.METADATA_KEY.format(
+            summaries_dir=NewsSummariesBucket.SUMMARIES_DIR,
+            stock=stock.upper(),
+            date=NewsSummariesBucket._get_datestamp(datestamp),
+        )
+
+    @staticmethod
+    def _get_summary_key(stock: str, datestamp: dt) -> str:
         return NewsSummariesBucket.SUMMARY_KEY.format(
             summaries_dir=NewsSummariesBucket.SUMMARIES_DIR,
             stock=stock.upper(),
-            date=NewsSummariesBucket._get_datestamp(timestamp),
+            date=NewsSummariesBucket._get_datestamp(datestamp),
         )
 
     @staticmethod

--- a/src/stocks/alphavantage/client.py
+++ b/src/stocks/alphavantage/client.py
@@ -118,7 +118,7 @@ class AlphaVantageClient:
             text = self.web_scraper.scrape(url)
             articles.append(NewsArticle(title=title, url=url, contents=text))
 
-        return CompanyNews(stock=symbol, articles=articles)
+        return CompanyNews(stock=symbol, datestamp=date, articles=articles)
 
     def search_stock(self, symbol: str) -> List[CompanySearch]:
         log.info(f"Searching for stocks with tickers similar to '{symbol}'")
@@ -168,7 +168,7 @@ class AlphaVantageClient:
         )
 
     @staticmethod
-    def _get_company_search(stock: dict) -> str:
+    def _get_company_search(stock: dict) -> CompanySearch:
         return CompanySearch(
             symbol=stock["1. symbol"],
             name=stock["2. name"],

--- a/src/stocks/alphavantage/models.py
+++ b/src/stocks/alphavantage/models.py
@@ -1,3 +1,4 @@
+import datetime
 from dataclasses import dataclass
 from typing import List
 
@@ -55,11 +56,13 @@ class CompanyNews:
     """
 
     stock: str
+    datestamp: datetime.datetime
     articles: List[NewsArticle]
 
     def to_dict(self) -> dict:
         return {
             "stock": self.stock,
+            "datestamp": self.datestamp.strftime("%Y-%m-%d"),
             "articles": [article.to_dict() for article in self.articles],
         }
 

--- a/src/summaries/client.py
+++ b/src/summaries/client.py
@@ -1,0 +1,88 @@
+import datetime as dt
+from dataclasses import dataclass
+
+from src.ai.client import WalterAI
+from src.config import CONFIG
+from src.stocks.alphavantage.models import CompanyNews
+from src.stocks.client import WalterStocksAPI
+from src.summaries.models import NewsSummary
+from src.utils.log import Logger
+
+log = Logger(__name__).get_logger()
+
+#############
+# CONSTANTS #
+#############
+
+CONTEXT = "You are a financial AI advisor that summaries market news and gives readers digestible, business casual insights about the latest market movements."
+"""(str): The context used to give to the LLM to generate news summaries."""
+
+PROMPT = "Summarize the following news article about the stock '{stock}' to give a well-written concise update of the stock and any market news relating to it but write it with headers and bodies so it looks like a formatted report:\n{news}"
+"""(str): The prompt used to give to the LLM to generate news summaries."""
+
+SUMMARY_MAX_LENGTH = CONFIG.news_summary.max_length
+"""(int): The length of the news summary is controlled by the max generation length of the LLM response."""
+
+##########
+# CLIENT #
+##########
+
+
+@dataclass
+class WalterNewsSummaryClient:
+    """
+    WalterNewsSummaryClient
+    """
+
+    walter_stock_api: WalterStocksAPI
+    walter_ai: WalterAI
+
+    def __post_init__(self) -> None:
+        log.debug("Initializing WalterNewsSummaryClient")
+
+    def generate(
+        self,
+        stock: str,
+        datestamp: dt.datetime,
+        number_of_articles=CONFIG.news_summary.number_of_articles,
+    ) -> NewsSummary | None:
+        log.info(
+            f"Generating '{stock.upper()}' stock news summary for date: '{datestamp.strftime('%Y-%m-%d')}'"
+        )
+        news = self._get_stock_news(stock, datestamp, number_of_articles)
+        return self._generate_news_summary(news)
+
+    def _get_stock_news(
+        self,
+        stock: str,
+        datestamp: dt.datetime,
+        numbers_of_articles: int = CONFIG.news_summary.number_of_articles,
+    ) -> CompanyNews:
+        log.info(
+            f"Getting latest '{stock.upper()}' stock news with latest published date: '{datestamp.strftime('%Y-%m-%d')}'"
+        )
+        news = self.walter_stock_api.get_news(stock, datestamp, numbers_of_articles)
+        if not news:
+            raise ValueError(
+                f"No '{stock.upper()}' stock news articles returned with latest published date: '{datestamp.strftime('%Y-%m-%d')}'!"
+            )
+        log.info(
+            f"Successfully returned {len(news.articles)} '{stock.upper()}' stock news articles!"
+        )
+        return news
+
+    def _generate_news_summary(self, news: CompanyNews) -> NewsSummary:
+        log.info(f"Generating news summary for '{news.stock.upper()}' stock news...")
+        summary = self.walter_ai.generate_response(
+            context=CONTEXT,
+            prompt=PROMPT.format(stock=news.stock, news=news.to_dict()),
+            max_output_tokens=SUMMARY_MAX_LENGTH,
+        )
+        log.info(f"Successfully generated '{news.stock.upper()}' stock news summary!")
+        return NewsSummary(
+            stock=news.stock,
+            datestamp=news.datestamp,
+            model_name=self.walter_ai.get_model().get_name(),
+            articles=news.articles,
+            summary=summary,
+        )

--- a/src/summaries/models.py
+++ b/src/summaries/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import List
+from datetime import datetime
 
 from src.stocks.alphavantage.models import NewsArticle
 
@@ -10,15 +11,26 @@ class NewsSummary:
     NewsSummary
     """
 
+    DATESTAMP_FORMAT = "%Y-%m-%d"
+
     stock: str
+    datestamp: datetime
     model_name: str
     articles: List[NewsArticle]
     summary: str
 
-    def to_dict(self) -> dict:
+    def get_metadata(self) -> dict:
         return {
-            "stock": self.stock,
             "model_name": self.model_name,
+            "stock": self.stock,
+            "datestamp": self.datestamp.strftime(NewsSummary.DATESTAMP_FORMAT),
             "articles": [article.to_dict() for article in self.articles],
+        }
+
+    def get_summary(self) -> dict:
+        return {
+            "model_name": self.model_name,
+            "stock": self.stock,
+            "datestamp": self.datestamp.strftime(NewsSummary.DATESTAMP_FORMAT),
             "summary": self.summary,
         }

--- a/src/utils/web_scraper.py
+++ b/src/utils/web_scraper.py
@@ -22,7 +22,7 @@ class WebScraper:
         log.debug("Initializing WebScraper")
 
     def scrape(self, url: str) -> str | None:
-        log.info(f"Scraping text contents from web page with URL: '{url}'")
+        log.debug(f"Scraping text contents from web page with URL: '{url}'")
 
         response = self._get_response(url)
         if response is None:

--- a/tst/news/test_news_bucket.py
+++ b/tst/news/test_news_bucket.py
@@ -1,9 +1,11 @@
+import datetime as dt
+
 import pytest
 
 from src.aws.s3.client import WalterS3Client
 from src.environment import Domain
 from src.news.bucket import NewsSummariesBucket
-import datetime as dt
+from src.summaries.models import NewsSummary
 
 ##########################
 # NEWS SUMMARIES BUCKETS #
@@ -18,8 +20,22 @@ NEWS_SUMMARIES_BUCKET_PROD = "walterai-news-summaries-prod"
 # NEWS SUMMARIES #
 ##################
 
+DATESTAMP = dt.datetime(
+    year=2025, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+)
+
+MSFT_SUMMARY_METADATA_KEY = "summaries/MSFT/y=2025/m=01/d=01/metadata.json"
 MSFT_SUMMARY_KEY = "summaries/MSFT/y=2025/m=01/d=01/summary.html"
+
+ABNB_SUMMARY_METADATA_KEY = "summaries/ABNB/y=2025/m=01/d=01/metadata.json"
 ABNB_SUMMARY_KEY = "summaries/ABNB/y=2025/m=01/d=01/summary.html"
+ABNB_SUMMARY = NewsSummary(
+    stock="ABNB",
+    datestamp=DATESTAMP,
+    model_name="unit-test",
+    articles=[],
+    summary="",
+)
 
 ################################
 # NEWS SUMMARIES BUCKET CLIENT #
@@ -40,19 +56,32 @@ def test_put_summary(
     news_summaries_bucket: NewsSummariesBucket, walter_s3: WalterS3Client
 ) -> None:
     stock = "ABNB"
-    now = dt.datetime.now()
     assert (
         walter_s3.get_object(
             NEWS_SUMMARIES_BUCKET_TEST,
-            f"summaries/{stock}/{now.strftime('y=%Y/m=%m/d=%d')}/summary.html",
+            f"summaries/{stock}/{DATESTAMP.strftime('y=%Y/m=%m/d=%d')}/metadata.json",
         )
         is None
     )
-    news_summaries_bucket.put_news_summary(stock, "summary")
     assert (
         walter_s3.get_object(
             NEWS_SUMMARIES_BUCKET_TEST,
-            f"summaries/{stock}/{now.strftime('y=%Y/m=%m/d=%d')}/summary.html",
+            f"summaries/{stock}/{DATESTAMP.strftime('y=%Y/m=%m/d=%d')}/summary.html",
+        )
+        is None
+    )
+    news_summaries_bucket.put_news_summary(ABNB_SUMMARY)
+    assert (
+        walter_s3.get_object(
+            NEWS_SUMMARIES_BUCKET_TEST,
+            f"summaries/{stock}/{DATESTAMP.strftime('y=%Y/m=%m/d=%d')}/metadata.json",
+        )
+        is not None
+    )
+    assert (
+        walter_s3.get_object(
+            NEWS_SUMMARIES_BUCKET_TEST,
+            f"summaries/{stock}/{DATESTAMP.strftime('y=%Y/m=%m/d=%d')}/summary.html",
         )
         is not None
     )
@@ -104,6 +133,18 @@ def test_get_news_summaries_bucket_name() -> None:
     assert (
         NewsSummariesBucket._get_bucket_name(Domain.PRODUCTION)
         == NEWS_SUMMARIES_BUCKET_PROD
+    )
+
+
+def test_get_news_summary_metadata_key() -> None:
+    datestamp = dt.datetime(year=2025, month=1, day=1)
+    assert (
+        NewsSummariesBucket._get_metadata_key("MSFT", datestamp)
+        == MSFT_SUMMARY_METADATA_KEY
+    )
+    assert (
+        NewsSummariesBucket._get_metadata_key("ABNB", datestamp)
+        == ABNB_SUMMARY_METADATA_KEY
     )
 
 


### PR DESCRIPTION
This PR refactors `WalterBackend` to dump the news summary generation metadata to S3 as well as the summary HTML file.

The metadata file is a JSON file that contains information about which model generated the summary, the datestamp of the summary, and the articles utilized to generate the summary. 

This is a good operational improvement because now S3 has essentially the inputs/outputs of Walter news summary generation which is an incredibly important aspect of Walter. The newsletters are only as good as the news summaries generated so investing in tooling here should be smart, I hope. 