### PR TITLE
test: Add unit tests for AddNewsSummaryRequests workflow

### DIFF
--- a/src/auth/authenticator.py
+++ b/src/auth/authenticator.py
@@ -45,15 +45,16 @@ class WalterAuthenticator:
             algorithm="HS256",
         )
 
-    def decode_user_token(self, token: str) -> bool | None:
+    def decode_user_token(self, token: str) -> dict | None:
         """
-        Decode the given user token to verify user identity.
+        Decode the given user token to verify identity.
 
         Args:
             token: The user identity token
 
         Returns:
-            True if the token is valid, False otherwise.
+            decoded_token_payload: The decoded token payload which includes the
+            email address of the authenticated user.
         """
         try:
             return jwt.decode(

--- a/tst/api/test_get_user.py
+++ b/tst/api/test_get_user.py
@@ -42,6 +42,6 @@ def test_get_user_failure_user_does_not_exist(get_user_api: GetUser) -> None:
         api_name=get_user_api.API_NAME,
         status_code=HTTPStatus.OK,
         status=Status.FAILURE,
-        message="Not authenticated!",
+        message="Not authenticated! Token is invalid.",
     )
     assert expected_response == get_user_api.invoke(event)

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -27,6 +27,7 @@ from src.database.stocks.models import Stock
 from src.database.users.models import User
 from src.database.userstocks.models import UserStock
 from src.environment import Domain
+from src.news.queue import NewsSummariesQueue
 from src.newsletters.queue import NewslettersQueue
 from src.stocks.alphavantage.models import CompanyOverview
 from src.stocks.client import WalterStocksAPI
@@ -60,6 +61,7 @@ USERS_TABLE_NAME = "Users-unittest"
 USERS_STOCKS_TABLE_NAME = "UsersStocks-unittest"
 
 NEWSLETTERS_QUEUE_NAME = "NewslettersQueue-unittest"
+NEWS_SUMMARIES_QUEUE_NAME = "NewsSummariesQueue-unittest"
 
 STOCKS_TEST_FILE = "tst/database/data/stocks.jsonl"
 USERS_TEST_FILE = "tst/database/data/users.jsonl"
@@ -200,6 +202,7 @@ def sqs_client() -> SQSClient:
     with mock_aws():
         mock_sqs = boto3.client("sqs", region_name=AWS_REGION)
         mock_sqs.create_queue(QueueName=NEWSLETTERS_QUEUE_NAME)
+        mock_sqs.create_queue(QueueName=NEWS_SUMMARIES_QUEUE_NAME)
         yield mock_sqs
 
 
@@ -499,6 +502,13 @@ def template_engine(templates_bucket: TemplatesBucket) -> None:
 @pytest.fixture
 def newsletters_queue(sqs_client) -> NewslettersQueue:
     return NewslettersQueue(
+        client=WalterSQSClient(client=sqs_client, domain=Domain.TESTING)
+    )
+
+
+@pytest.fixture
+def news_summaries_queue(sqs_client) -> NewsSummariesQueue:
+    return NewsSummariesQueue(
         client=WalterSQSClient(client=sqs_client, domain=Domain.TESTING)
     )
 

--- a/tst/workflows/test_add_news_summary_requests.py
+++ b/tst/workflows/test_add_news_summary_requests.py
@@ -1,0 +1,41 @@
+import json
+
+import pytest
+
+from src.api.common.models import HTTPStatus, Status
+from src.aws.cloudwatch.client import WalterCloudWatchClient
+from src.database.client import WalterDB
+from src.news.queue import NewsSummariesQueue
+from src.workflows.add_news_summary_requests import AddNewsSummaryRequests
+
+TEST_EVENT = {}
+"""(dict): Test event to trigger AddNewsSummaryRequests workflow (event is empty because job is simply triggered by cron schedule)."""
+
+
+@pytest.fixture
+def add_news_summary_requests_workflow(
+    walter_db: WalterDB,
+    news_summaries_queue: NewsSummariesQueue,
+    walter_cw: WalterCloudWatchClient,
+) -> AddNewsSummaryRequests:
+    return AddNewsSummaryRequests(walter_db, news_summaries_queue, walter_cw)
+
+
+def test_add_news_summary_requests_success(
+    add_news_summary_requests_workflow: AddNewsSummaryRequests,
+) -> None:
+    response = add_news_summary_requests_workflow.invoke(TEST_EVENT)
+    assert response == {
+        "statusCode": HTTPStatus.OK.value,
+        "body": json.dumps(
+            {
+                "Workflow": "AddNewsSummaryRequests",
+                "Status": Status.SUCCESS.value,
+                "Message": "Added news summary requests!",
+                "Data": {
+                    "news_summary_queue": "https://sqs.us-east-1.amazonaws.com/012345678901/NewsSummariesQueue-unittest",
+                    "number_of_stocks": 6,
+                },
+            }
+        ),
+    }

--- a/walter.py
+++ b/walter.py
@@ -29,7 +29,7 @@ from src.clients import (
     news_summaries_queue,
 )
 from src.workflows.add_news_summary_requests import (
-    add_news_summary_requests_workflow,
+    AddNewsSummaryRequests,
 )
 from src.workflows.add_newsletter_requests import add_newsletter_requests_workflow
 from src.workflows.create_news_summary_and_archive import (
@@ -167,7 +167,9 @@ def create_newsletter_and_send_entrypoint(event, context) -> dict:
 
 
 def add_news_summary_requests_entrypoint(event, context) -> dict:
-    return add_news_summary_requests_workflow(event, context)
+    return AddNewsSummaryRequests(walter_db, news_summaries_queue, walter_cw).invoke(
+        event
+    )
 
 
 def create_news_summary_and_archive_entrypoint(event, context) -> dict:


### PR DESCRIPTION
Get that unit test coverage up boiiiii.

Also, can regress relatively often with untested workflows as these are essentially the backbone of Walter. Unit tests at least ensure that there are no silly errors that aren't caught until runtime because Python is interpreted.