### PR TITLE
feat: Add news summary generation context and prompt to configs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,8 @@ walter_config:
   news_summary:
     number_of_articles: 10 # the number of the most relevant news articles to parse when generating news summaries
     lookback_window_days: 365 # the number of days to lookback when querying for recent stock news
+    context: "You are a AI investment portfolio advisor that summarizes stock market news and gives readers digestible, business insights about the latest stock market movements to help them stay informed."
+    prompt: "Summarize the following news article about the stock '{stock}' to give a well-written concise update of the stock and any market news relating to it but write it with headers and bodies so it looks like a formatted report. Include data where possible and only focus on the most important updates, do not simply summarize each article separately:\n{news}"
     max_length: 5000 # the max length of generated news summaries
     schedule: cron(0 5 * * ? *) # the cron schedule to invoke the create news summary and archive workflow
   newsletter:

--- a/src/ai/amazon/models.py
+++ b/src/ai/amazon/models.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import dataclass
 
 from src.ai.common.model import WalterFoundationModel
@@ -30,8 +29,8 @@ class NovaMicro(WalterFoundationModel):
             top_p,
         )
 
-    def _get_body(self, prompt: str, max_output_tokens: int) -> str:
-        request = {
+    def _get_body(self, prompt: str, max_output_tokens: int) -> dict:
+        return {
             "inferenceConfig": {"max_new_tokens": max_output_tokens},
             "messages": [
                 {
@@ -40,7 +39,6 @@ class NovaMicro(WalterFoundationModel):
                 }
             ],
         }
-        return json.dumps(request)
 
     def _parse_response(self, response: dict) -> str:
         return response["output"]["message"]["content"][0]["text"]

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -31,7 +31,7 @@ class WalterAI:
 
     def get_model(self) -> WalterFoundationModel:
         model = get_model(self.model)
-        log.info(f"Getting model: '{model.value}'")
+        log.debug(f"Getting model: '{model.value}'")
 
         if model == Model.META_LLAMA3_70B:
             return Llama370B(

--- a/src/ai/common/model.py
+++ b/src/ai/common/model.py
@@ -64,7 +64,7 @@ class WalterFoundationModel(ABC):
             raise ValueError("Prompt too long!")
 
     @abstractmethod
-    def _get_body(self, prompt: str, max_output_tokens: int) -> str:
+    def _get_body(self, prompt: str, max_output_tokens: int) -> dict:
         pass
 
     @abstractmethod

--- a/src/aws/bedrock/client.py
+++ b/src/aws/bedrock/client.py
@@ -29,7 +29,7 @@ class WalterBedrockClient:
             f"Creating Bedrock client in region '{self.bedrock.meta.region_name}'"
         )
 
-    def generate_response(self, model_id: str, body: str) -> dict:
+    def generate_response(self, model_id: str, body: dict) -> dict:
         """
         Invoke the model and get a response for a single prompt.
 
@@ -44,7 +44,7 @@ class WalterBedrockClient:
             log.info(f"Generating response with model '{model_id}'")
             response = self.bedrock_runtime.invoke_model(
                 modelId=model_id,
-                body=body,
+                body=json.dumps(body),
             )
             return json.loads(response["body"].read())
         except Exception as exception:

--- a/src/config.py
+++ b/src/config.py
@@ -42,13 +42,17 @@ class NewsSummaryConfig:
 
     number_of_articles: int = 10
     lookback_window_days: int = 90
+    context: str = "You are an AI investment advisor."
+    prompt: str = "Summarize the following '{stock}' news articles:\n{news}"
     max_length: int = 5000
-    schedule: str = "0 5 * * ? *"  # every day at midnight EDT
+    schedule: str = "cron(0 5 * * ? *)"  # every day at midnight EDT
 
     def to_dict(self) -> dict:
         return {
             "number_of_articles": self.number_of_articles,
             "lookback_window_days": self.lookback_window_days,
+            "context": self.context,
+            "prompt": self.prompt,
             "max_length": self.max_length,
             "schedule": self.schedule,
         }
@@ -60,7 +64,7 @@ class NewsletterConfig:
 
     template: str = "default"
     max_length: int = 2000
-    schedule: str = "0 11 ? * MON-FRI *"  # every business day at 6am EDT
+    schedule: str = "cron(0 11 ? * MON-FRI *)"  # every business day at 6am EDT
 
     def to_dict(self) -> dict:
         return {
@@ -130,6 +134,8 @@ def get_walter_config() -> WalterConfig:
                 lookback_window_days=config_yaml["news_summary"][
                     "lookback_window_days"
                 ],
+                context=config_yaml["news_summary"]["context"],
+                prompt=config_yaml["news_summary"]["prompt"],
                 max_length=config_yaml["news_summary"]["max_length"],
                 schedule=config_yaml["news_summary"]["schedule"],
             ),

--- a/src/summaries/client.py
+++ b/src/summaries/client.py
@@ -48,13 +48,16 @@ class WalterNewsSummaryClient:
         start_date: dt.datetime,
         end_date: dt.datetime,
         number_of_articles: int = CONFIG.news_summary.number_of_articles,
+        context: str = CONFIG.news_summary.context,
+        prompt: str = CONFIG.news_summary.prompt,
+        max_length: int = CONFIG.news_summary.max_length,
     ) -> NewsSummary:
         log.info(
             f"Generating '{stock.upper()}' news summary for date '{end_date.strftime('%Y-%m-%d')}'"
         )
         try:
             news = self._get_stock_news(stock, start_date, end_date, number_of_articles)
-            return self._generate_news_summary(news)
+            return self._generate_news_summary(news, context, prompt, max_length)
         except CompanyNewsNotFound:
             raise GenerateNewsSummaryFailure(
                 f"Cannot generate news summary for stock '{stock.upper()}'! No stock news found."
@@ -75,12 +78,18 @@ class WalterNewsSummaryClient:
         )
         return news
 
-    def _generate_news_summary(self, news: CompanyNews) -> NewsSummary:
+    def _generate_news_summary(
+        self,
+        news: CompanyNews,
+        context: str = CONFIG.news_summary.context,
+        prompt: str = CONFIG.news_summary.prompt,
+        max_length: int = CONFIG.news_summary.max_length,
+    ) -> NewsSummary:
         log.info(f"Generating news summary for '{news.stock.upper()}' stock news...")
         summary = self.walter_ai.generate_response(
-            context=CONTEXT,
-            prompt=PROMPT.format(stock=news.stock, news=news.to_dict()),
-            max_output_tokens=SUMMARY_MAX_LENGTH,
+            context=context,
+            prompt=prompt.format(stock=news.stock.upper(), news=news.to_dict()),
+            max_output_tokens=max_length,
         )
         log.info(f"Successfully generated '{news.stock.upper()}' stock news summary!")
         return NewsSummary(

--- a/src/workflows/create_news_summary_and_archive.py
+++ b/src/workflows/create_news_summary_and_archive.py
@@ -88,6 +88,9 @@ class CreateNewsSummaryAndArchive:
                 event.datestamp,
                 CONFIG.news_summary.lookback_window_days,
                 CONFIG.news_summary.number_of_articles,
+                CONFIG.news_summary.context,
+                CONFIG.news_summary.prompt,
+                CONFIG.news_summary.max_length,
             )
 
             if generated_summary is None:
@@ -135,6 +138,9 @@ class CreateNewsSummaryAndArchive:
         date: dt.datetime,
         lookback_window_days: int = CONFIG.news_summary.lookback_window_days,
         number_of_articles: int = CONFIG.news_summary.number_of_articles,
+        context: str = CONFIG.news_summary.context,
+        prompt: str = CONFIG.news_summary.prompt,
+        max_length: int = CONFIG.news_summary.max_length,
     ) -> NewsSummary | None:
         log.info("News summary not found in archive! Generating news summary now...")
         try:
@@ -143,6 +149,9 @@ class CreateNewsSummaryAndArchive:
                 start_date=date - timedelta(days=lookback_window_days),
                 end_date=date,
                 number_of_articles=number_of_articles,
+                context=context,
+                prompt=prompt,
+                max_length=max_length,
             )
         except GenerateNewsSummaryFailure:
             log.error(f"Failed to generate news summary for stock '{stock.upper()}'!")

--- a/tst/workflows/test_create_news_summary_and_archive.py
+++ b/tst/workflows/test_create_news_summary_and_archive.py
@@ -57,6 +57,9 @@ class MockWalterNewsSummaryClient:
         start_date: dt.datetime,
         end_date: dt.datetime,
         number_of_articles: int,
+        context: str,
+        prompt: str,
+        max_length: int
     ) -> NewsSummary | None:
         if stock.upper() == MSFT_STOCK:
             return MSFT_NEWS_SUMMARY


### PR DESCRIPTION
This PR adds two new configs to the Walter news summary configurations: `context` and `prompt`.

Currently, Walter's news summarizations is pretty simple, just a single prompt with context so we don't need to make use of a complex `TemplateSpec` like the newsletter does.

This allows us to control/tweak news summarization from the configs and version control it. 