### PR TITLE
Revert "feat: Parallelize batch get prices from Polygon (#293)"

### DIFF
--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -1448,7 +1448,7 @@ Resources:
     Type: AWS::Lambda::Alias
     Properties:
       FunctionName: !Ref WalterAPIGetPortfolio
-      FunctionVersion: 20
+      FunctionVersion: 16
       Name: "release"
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: !Ref WalterAPILambdaProvisionedConcurrencyCount

--- a/src/stocks/polygon/client.py
+++ b/src/stocks/polygon/client.py
@@ -1,4 +1,3 @@
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timedelta, UTC
 from typing import Dict, List
@@ -68,21 +67,8 @@ class PolygonClient:
         self._init_rest_client()
 
         prices = {}
-        with ThreadPoolExecutor() as executor:
-            future_to_symbol = {
-                executor.submit(
-                    self.get_prices, stock, start_date, end_date
-                ): stock.stock_symbol
-                for stock in stocks.values()
-            }
-
-            for future in as_completed(future_to_symbol):
-                symbol = future_to_symbol[future]
-                try:
-                    prices[symbol] = future.result()
-                except Exception as e:
-                    log.error(f"Error getting prices for {symbol}: {str(e)}")
-                    prices[symbol] = StockPrices(prices=[])
+        for stock in stocks.values():
+            prices[stock.stock_symbol] = self.get_prices(stock, start_date, end_date)
 
         return prices
 


### PR DESCRIPTION
This reverts commit 35a2b18c1c560df1cff5bda4d1f2808f16ac7f30.

Polygon REST client connection pool is getting exhausted... Revert back to synchronous calls for now.

Investigate better solution later but this actually caused an increase in API latency so reverting for now.