### PR TITLE
fix: ensure new cash accounts have unique identifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ help:
 	@echo "  make format         	  Auto-format code"
 	@echo "  make lint                Lint code"
 	@echo "  make test    	     	  Run unit test suite"
-	@echo "  make update-image   	  Update WalterAPI image"
 	@echo "  make update-src     	  Update Walter API src code"
-	@echo "  make update-funcs        Update Walter API functions"
+	@echo "  make update-image   	  Update WalterAPI image"
+	@echo "  make update-infra        Update Walter API infra"
 
 
 format:
@@ -38,3 +38,6 @@ update-src:
 	&& aws s3 cp walter-backend.zip s3://walter-backend-src/walter-backend.zip \
 	&& rm -rf walter-backend \
 	&& rm -rf walter-backend.zip
+
+update-infra:
+	pipenv run python buildspec.py

--- a/infra/infra.yml
+++ b/infra/infra.yml
@@ -1709,7 +1709,7 @@ Resources:
     Type: AWS::Lambda::Alias
     Properties:
       FunctionName: !Ref WalterAPIAddStock
-      FunctionVersion: 36
+      FunctionVersion: 73
       Name: "release"
 
   WalterAPIAddStock:
@@ -1737,7 +1737,7 @@ Resources:
     Type: AWS::Lambda::Alias
     Properties:
       FunctionName: !Ref WalterAPIDeleteStock
-      FunctionVersion: 33
+      FunctionVersion: 70
       Name: "release"
 
   WalterAPIDeleteStock:
@@ -2324,7 +2324,7 @@ Resources:
     Type: AWS::Lambda::Alias
     Properties:
       FunctionName: !Ref WalterAPICreateCashAccount
-      FunctionVersion: 2
+      FunctionVersion: 29
       Name: "release"
 
   WalterAPICreateCashAccount:
@@ -2382,7 +2382,7 @@ Resources:
     Type: AWS::Lambda::Alias
     Properties:
       FunctionName: !Ref WalterAPIAddTransaction
-      FunctionVersion: 15
+      FunctionVersion: 37
       Name: "release"
 
   WalterAPIAddTransaction:
@@ -2410,7 +2410,7 @@ Resources:
     Type: AWS::Lambda::Alias
     Properties:
       FunctionName: !Ref WalterAPIEditTransaction
-      FunctionVersion: 15
+      FunctionVersion: 37
       Name: "release"
 
   WalterAPIEditTransaction:
@@ -2438,7 +2438,7 @@ Resources:
     Type: AWS::Lambda::Alias
     Properties:
       FunctionName: !Ref WalterAPIDeleteTransaction
-      FunctionVersion: 15
+      FunctionVersion: 37
       Name: "release"
 
   WalterAPIDeleteTransaction:

--- a/src/api/create_cash_account.py
+++ b/src/api/create_cash_account.py
@@ -55,7 +55,7 @@ class CreateCashAccount(WalterAPIMethod):
 
     def execute(self, event: dict, authenticated_email: str) -> Response:
         user = self._verify_user_exists(authenticated_email)
-        cash_account = self._create_cash_account(user, event)
+        cash_account = self._create_new_cash_account(user, event)
         return Response(
             api_name=CreateCashAccount.API_NAME,
             http_status=HTTPStatus.CREATED,
@@ -90,11 +90,11 @@ class CreateCashAccount(WalterAPIMethod):
         log.info("User verified successfully!")
         return user
 
-    def _create_cash_account(self, user: User, event: dict) -> CashAccount:
-        log.info("Creating cash account for user")
+    def _create_new_cash_account(self, user: User, event: dict) -> CashAccount:
+        log.info("Creating new cash account for user")
 
         body = json.loads(event["body"])
-        cash_account = CashAccount.create_account(
+        cash_account = CashAccount.create_new_account(
             user,
             bank_name=body["bank_name"],
             account_name=body["account_name"],

--- a/src/database/cash_accounts/models.py
+++ b/src/database/cash_accounts/models.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import uuid
 from dataclasses import dataclass
 from enum import Enum
 
@@ -106,6 +107,47 @@ class CashAccount:
     @staticmethod
     def get_account_id_key(account_id: str) -> str:
         return CashAccount.ACCOUNT_ID_KEY_FORMAT.format(account_id=account_id)
+
+    @classmethod
+    def create_new_account(
+        cls,
+        user: User,
+        bank_name: str,
+        account_name: str,
+        account_type: CashAccountType,
+        account_last_four_numbers: str,
+        balance: float,
+    ):
+        """
+        Create a new cash account with the given parameters.
+
+        Use this class method to create a new cash account that does
+        not already exist. This method differs from the `create_account`
+        class method as that method is meant to marshal the given parameters
+        of an existing cash account into the `CashAccount` model.
+
+        Args:
+            user: The user that owns the new cash account.
+            bank_name: The name of the bank that owns the new cash account.
+            account_name: The account name of the new cash account.
+            account_type: The type of the new cash account.
+            account_last_four_numbers: The new cash account's last four numbers.
+            balance: The starting balance of the new cash account.
+
+        Returns:
+            (CashAccount): The new cash account with a unique ID.
+        """
+        # create a new unique identifier since its a new cash acct
+        new_account_id = str(uuid.uuid4())
+        return CashAccount.create_account(
+            user=user,
+            account_id=new_account_id,
+            bank_name=bank_name,
+            account_name=account_name,
+            account_type=account_type,
+            account_last_four_numbers=account_last_four_numbers,
+            balance=balance,
+        )
 
     @classmethod
     def create_account(


### PR DESCRIPTION
The `CreateCashAccount` API was throwing internal server errors because the method used to create new accounts didn't supply a unique ID.

This PR separates the logic for marshaling raw params from the DB to a `CashAccount` model object and creating a new cash account from user-supplied raw params to account for each use case.

Now, users can create completely new cash accounts via the UI. I think this functionality broke when updating the integration with Plaid. 