### PR TITLE
fix: update git tags logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy WalterBackend to Development
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/deploy.py
+++ b/deploy.py
@@ -338,7 +338,7 @@ def ensure_git_tag() -> None:
 
     # Force-create the tag
     print(f"Creating annotated tag '{VERSION_TAG}'...")
-    run_cmd(["git", "tag", "-fa", VERSION_TAG, "-m", RELEASE_DESCRIPTION])
+    run_cmd(["git", "tag", "-fa", VERSION_TAG, "-m", f"{RELEASE_DESCRIPTION}"])
 
     # Push the tag (force to ensure update)
     print(f"Pushing tag '{VERSION_TAG}' to origin...")


### PR DESCRIPTION
## Summary

The git tagging logic in the CI `deploy.py` script is still having issues when tagging commits on the `main` branch. This is another attempt to fix those issues.

## Context

`WalterBackend` should use git tags to help manage releases and deployments of the image to different environments.

## Changes

- Fix some of the git tag commands in the `deploy.py` script

## Testing

I am going to temporarily allow the deploy action to run on pull requests to `main` to test the action more thoroughly before looking to merge.

After testing, this PR should ensure that the deploy action is then restricted again to only run on pushes/merges to `main`.

## Notes

N/A
