### PR TITLE
fix: add client factory to canary router

### DIFF
--- a/src/canaries/routing/router.py
+++ b/src/canaries/routing/router.py
@@ -9,7 +9,7 @@ from src.canaries.common.canary import BaseCanary
 from src.canaries.transactions.get_transactions import GetTransactions
 from src.canaries.users.create_user import CreateUser
 from src.canaries.users.get_user import GetUser
-from src.clients import AUTHENTICATOR, DATABASE, DATADOG
+from src.factory import ClientFactory
 from src.utils.log import Logger
 
 log = Logger(__name__).get_logger()
@@ -57,24 +57,53 @@ class CanaryType(Enum):
 class CanaryRouter:
     """Router for Canaries"""
 
-    @staticmethod
-    def get_canary(canary_type: CanaryType) -> BaseCanary:
+    client_factory: ClientFactory
+
+    def get_canary(self, canary_type: CanaryType) -> BaseCanary:
         log.info(f"Getting '{canary_type.value}' canary'")
 
         match canary_type:
             case CanaryType.LOGIN:
-                return Login(AUTHENTICATOR, DATABASE, DATADOG)
+                return Login(
+                    authenticator=self.client_factory.get_authenticator(),
+                    db=self.client_factory.get_db_client(),
+                    metrics=self.client_factory.get_metrics_client(),
+                )
             case CanaryType.REFRESH:
-                return Refresh(AUTHENTICATOR, DATABASE, DATADOG)
+                return Refresh(
+                    authenticator=self.client_factory.get_authenticator(),
+                    db=self.client_factory.get_db_client(),
+                    metrics=self.client_factory.get_metrics_client(),
+                )
             case CanaryType.LOGOUT:
-                return Logout(AUTHENTICATOR, DATABASE, DATADOG)
+                return Logout(
+                    authenticator=self.client_factory.get_authenticator(),
+                    db=self.client_factory.get_db_client(),
+                    metrics=self.client_factory.get_metrics_client(),
+                )
             case CanaryType.GET_USER:
-                return GetUser(AUTHENTICATOR, DATABASE, DATADOG)
+                return GetUser(
+                    authenticator=self.client_factory.get_authenticator(),
+                    db=self.client_factory.get_db_client(),
+                    metrics=self.client_factory.get_metrics_client(),
+                )
             case CanaryType.CREATE_USER:
-                return CreateUser(AUTHENTICATOR, DATABASE, DATADOG)
+                return CreateUser(
+                    authenticator=self.client_factory.get_authenticator(),
+                    db=self.client_factory.get_db_client(),
+                    metrics=self.client_factory.get_metrics_client(),
+                )
             case CanaryType.GET_ACCOUNTS:
-                return GetAccounts(AUTHENTICATOR, DATABASE, DATADOG)
+                return GetAccounts(
+                    authenticator=self.client_factory.get_authenticator(),
+                    db=self.client_factory.get_db_client(),
+                    metrics=self.client_factory.get_metrics_client(),
+                )
             case CanaryType.GET_TRANSACTIONS:
-                return GetTransactions(AUTHENTICATOR, DATABASE, DATADOG)
+                return GetTransactions(
+                    authenticator=self.client_factory.get_authenticator(),
+                    db=self.client_factory.get_db_client(),
+                    metrics=self.client_factory.get_metrics_client(),
+                )
             case _:
                 raise Exception(f"Canary type {canary_type} not found.")

--- a/tst/canary/test_canary_router.py
+++ b/tst/canary/test_canary_router.py
@@ -1,0 +1,27 @@
+import pytest
+
+from src.canaries.accounts.get_accounts import GetAccounts
+from src.canaries.auth.login import Login
+from src.canaries.auth.logout import Logout
+from src.canaries.auth.refresh import Refresh
+from src.canaries.routing.router import CanaryRouter, CanaryType
+from src.canaries.transactions.get_transactions import GetTransactions
+from src.canaries.users.create_user import CreateUser
+from src.canaries.users.get_user import GetUser
+
+
+def test_get_canary_success(canary_router: CanaryRouter) -> None:
+    assert isinstance(canary_router.get_canary(CanaryType.LOGIN), Login)
+    assert isinstance(canary_router.get_canary(CanaryType.REFRESH), Refresh)
+    assert isinstance(canary_router.get_canary(CanaryType.LOGOUT), Logout)
+    assert isinstance(canary_router.get_canary(CanaryType.GET_USER), GetUser)
+    assert isinstance(canary_router.get_canary(CanaryType.CREATE_USER), CreateUser)
+    assert isinstance(canary_router.get_canary(CanaryType.GET_ACCOUNTS), GetAccounts)
+    assert isinstance(
+        canary_router.get_canary(CanaryType.GET_TRANSACTIONS), GetTransactions
+    )
+
+
+def test_get_canary_failure(canary_router: CanaryRouter) -> None:
+    with pytest.raises(Exception):
+        canary_router.get_canary("invalid-canary")

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -15,6 +15,7 @@ from src.aws.s3.client import WalterS3Client
 from src.aws.secretsmanager.client import WalterSecretsManagerClient
 from src.aws.ses.client import WalterSESClient
 from src.aws.sqs.client import WalterSQSClient
+from src.canaries.routing.router import CanaryRouter
 from src.database.client import WalterDB
 from src.environment import Domain
 from src.factory import ClientFactory
@@ -234,3 +235,8 @@ def client_factory(
 @pytest.fixture
 def api_method_factory(client_factory: ClientFactory) -> APIMethodFactory:
     return APIMethodFactory(client_factory=client_factory)
+
+
+@pytest.fixture
+def canary_router(client_factory: ClientFactory) -> CanaryRouter:
+    return CanaryRouter(client_factory=client_factory)


### PR DESCRIPTION
## Summary

`WalterBackend` seemed to be having some issues with serving API requests and invoking canaries due to a nonexistent import in the Canary router class.

This PR removes the nonexistent imports to fix the runtime issues.

Good news is the monitors did successfully catch this issue!

## Context

`WalterBackend` is broken right now due to nonexistent imports. This PR fixes those issues.

## Changes

- Remove nonexistent imports from Canary router

## Testing

- Deployed changes to `dev` and E2E tested API via `curl` commands

## Notes

N/A
