### PR TITLE
fix: fix failing canaries

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4,6 +4,8 @@ from typing import Optional
 import typer
 
 from src.api.router import API_ROUTER
+from src.canaries.router import CANARY_ROUTER
+from src.canaries.routing.router import CanaryType
 from src.database.transactions.models import TransactionType
 from src.utils.log import Logger
 from src.workflows.router import WORKFLOW_ROUTER
@@ -447,29 +449,29 @@ def create_link_token(token: str = None) -> None:
 ############
 
 
-# @app.command()
-# def canary(
-#     api: str = typer.Option(
-#         None,
-#         help=f"The name of the API the canary invokes. Defaults to None which invokes all canaries. Valid canary options: {[canary.value for canary in CanaryType]})",
-#     )
-# ) -> None:
-#     """
-#     This CLI command invokes a canary to test API endpoints.
-#
-#     The canary is invoked using the specified API. If no API is specified, all canaries are invoked.
-#     """
-#     log.info("WalterCLI: Canary")
-#     if api:
-#         log.info(f"Invoking canary for '{api}'")
-#         canary_type = CanaryType.from_string(api)
-#         response = CanaryRouter.get_canary(canary_type).invoke(emit_metrics=False)
-#         log.info(f"WalterCLI: Canary Response:\n{parse_response(response)}")
-#     else:
-#         log.info("Invoking all canaries")
-#         for canary_type in CanaryType:
-#             response = CanaryRouter.get_canary(canary_type).invoke(emit_metrics=False)
-#             log.info(f"WalterCLI: {canary_type} Response:\n{parse_response(response)}")
+@app.command()
+def canary(
+    api: str = typer.Option(
+        None,
+        help=f"The name of the API the canary invokes. Defaults to None which invokes all canaries. Valid canary options: {[canary.value for canary in CanaryType]})",
+    )
+) -> None:
+    """
+    This CLI command invokes a canary to test API endpoints.
+
+    The canary is invoked using the specified API. If no API is specified, all canaries are invoked.
+    """
+    log.info("WalterCLI: Canary")
+    if api:
+        log.info(f"Invoking canary for '{api}'")
+        canary_type = CanaryType.from_string(api)
+        response = CANARY_ROUTER.get_canary(canary_type).invoke(emit_metrics=False)
+        log.info(f"WalterCLI: Canary Response:\n{parse_response(response)}")
+    else:
+        log.info("Invoking all canaries")
+        for canary_type in CanaryType:
+            response = CANARY_ROUTER.get_canary(canary_type).invoke(emit_metrics=False)
+            log.info(f"WalterCLI: {canary_type} Response:\n{parse_response(response)}")
 
 
 #############

--- a/src/canaries/router.py
+++ b/src/canaries/router.py
@@ -1,0 +1,5 @@
+from src.canaries.routing.router import CanaryRouter
+from src.factory import CLIENT_FACTORY
+
+CANARY_ROUTER: CanaryRouter = CanaryRouter(client_factory=CLIENT_FACTORY)
+"""(CanaryRouter): The canary router used to route canary requests to the appropriate canary execution method."""

--- a/walter.py
+++ b/walter.py
@@ -2,7 +2,8 @@ import json
 
 from src.api.common.models import HTTPStatus, Status
 from src.api.router import API_ROUTER
-from src.canaries.routing.router import CanaryRouter, CanaryType
+from src.canaries.router import CANARY_ROUTER
+from src.canaries.routing.router import CanaryType
 from src.utils.log import Logger
 from src.workflows.router import WORKFLOW_ROUTER
 
@@ -43,7 +44,7 @@ def canaries_entrypoint(event, context) -> dict:
     # iterate over all canaries and invoke them
     responses = []
     for canary_type in CanaryType:
-        response = CanaryRouter.get_canary(canary_type).invoke(emit_metrics=True)
+        response = CANARY_ROUTER.get_canary(canary_type).invoke(emit_metrics=True)
         responses.append(json.loads(response["body"]))
 
     # count successful and failed canaries


### PR DESCRIPTION
## Summary

The canaries are all failing right now due to a simple syntax bug. 

This PR fixes the canary syntax bug and updates the CLI for canary testing.

## Context

The canaries are all failing and the corresponding monitors are in alarm.

## Changes

- Fix canary router syntax bug after recent client factory updates

## Testing

- Local testing with CLI tool against all canaries

## Notes

N/A
