### PR TITLE
feat: set cookies securely on auth apis

### DIFF
--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -111,9 +111,12 @@ get_lambda_function_versions() {
     fetch_latest_version() {
         local function_name="$1"
         aws lambda list-versions-by-function \
-            --function-name "$function_name" \
-            --query "Versions[?Version!='\$LATEST'] | sort_by(@, &to_number(Version))[-1].Version" \
-            --output text 2>/dev/null
+          --function-name "$function_name" \
+          --query 'Versions[?Version!=`$LATEST`].Version' \
+          --output text 2>/dev/null | \
+        tr '\t' '\n' | \
+        sort -n | \
+        tail -1
     }
 
 

--- a/src/api/accounts/create_account.py
+++ b/src/api/accounts/create_account.py
@@ -60,10 +60,10 @@ class CreateAccount(WalterAPIMethod):
         user = self._verify_user_exists(session.user_id)
         account = self._create_new_account(user, event)
         return self._create_response(
-            HTTPStatus.CREATED,
-            Status.SUCCESS,
-            "Account created successfully!",
-            {"account": account.to_dict()},
+            http_status=HTTPStatus.CREATED,
+            status=Status.SUCCESS,
+            message="Account created successfully!",
+            data={"account": account.to_dict()},
         )
 
     def validate_fields(self, event: dict) -> None:

--- a/src/api/accounts/delete_account.py
+++ b/src/api/accounts/delete_account.py
@@ -60,9 +60,9 @@ class DeleteAccount(WalterAPIMethod):
         self._verify_account_exists(user, event)
         self._delete_account(user, event)
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Successfully deleted account!",
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Successfully deleted account!",
         )
 
     def validate_fields(self, event: dict) -> None:

--- a/src/api/accounts/update_account.py
+++ b/src/api/accounts/update_account.py
@@ -71,10 +71,10 @@ class UpdateAccount(WalterAPIMethod):
         account = self._verify_account_exists(user, event)
         updated_account = self._update_account(user, account, event)
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Account updated successfully!",
-            {"account": updated_account.to_dict()},
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Account updated successfully!",
+            data={"account": updated_account.to_dict()},
         )
 
     def validate_fields(self, event: dict) -> None:

--- a/src/api/auth/login/method.py
+++ b/src/api/auth/login/method.py
@@ -76,10 +76,14 @@ class Login(WalterAPIMethod):
         self._create_session(user, tokens, event)
         self._update_last_active_date(user)
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "User logged in successfully!",
-            LoginResponse(user, tokens).to_dict(),
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="User logged in successfully!",
+            cookies={
+                "WALTER_BACKEND_ACCESS_TOKEN": tokens.access_token,
+                "WALTER_BACKEND_REFRESH_TOKEN": tokens.refresh_token,
+            },
+            data=LoginResponse(user, tokens).to_dict(),
         )
 
     def validate_fields(self, event: dict) -> None:

--- a/src/api/auth/login/models.py
+++ b/src/api/auth/login/models.py
@@ -13,8 +13,6 @@ class LoginResponse:
     def to_dict(self) -> dict:
         return {
             "user_id": self.user.user_id,
-            "access_token": self.tokens.access_token,
-            "refresh_token": self.tokens.refresh_token,
             "access_token_expires_at": self.tokens.access_token_expiry.isoformat(),
             "refresh_token_expires_at": self.tokens.refresh_token_expiry.isoformat(),
         }

--- a/src/api/auth/logout/method.py
+++ b/src/api/auth/logout/method.py
@@ -98,9 +98,9 @@ class Logout(WalterAPIMethod):
         )
 
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "User logged out successfully!",
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="User logged out successfully!",
             data={
                 "user_id": user_id,
                 "session_id": token_id,

--- a/src/api/auth/logout/method.py
+++ b/src/api/auth/logout/method.py
@@ -101,4 +101,10 @@ class Logout(WalterAPIMethod):
             HTTPStatus.OK,
             Status.SUCCESS,
             "User logged out successfully!",
+            data={
+                "user_id": user_id,
+                "session_id": token_id,
+                "session_start": session.session_start.isoformat(),
+                "session_end": session.session_end.isoformat(),
+            },
         )

--- a/src/api/auth/refresh/method.py
+++ b/src/api/auth/refresh/method.py
@@ -77,10 +77,12 @@ class Refresh(WalterAPIMethod):
         self._verify_valid_session(session)
         access_token, access_token_expiry = self._generate_new_access_token(session)
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Access token refreshed!",
-            RefreshResponseData(user_id, access_token, access_token_expiry).to_dict(),
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Access token refreshed!",
+            data=RefreshResponseData(
+                user_id, access_token, access_token_expiry
+            ).to_dict(),
         )
 
     def _get_refresh_token(self, event: dict) -> str:

--- a/src/api/auth/refresh/method.py
+++ b/src/api/auth/refresh/method.py
@@ -80,9 +80,10 @@ class Refresh(WalterAPIMethod):
             http_status=HTTPStatus.OK,
             status=Status.SUCCESS,
             message="Access token refreshed!",
-            data=RefreshResponseData(
-                user_id, access_token, access_token_expiry
-            ).to_dict(),
+            cookies={
+                "WALTER_BACKEND_ACCESS_TOKEN": access_token,
+            },
+            data=RefreshResponseData(user_id, access_token_expiry).to_dict(),
         )
 
     def _get_refresh_token(self, event: dict) -> str:

--- a/src/api/auth/refresh/models.py
+++ b/src/api/auth/refresh/models.py
@@ -7,12 +7,10 @@ class RefreshResponseData:
     """Refresh Response"""
 
     user_id: str
-    access_token: str
     access_token_expiration: datetime
 
     def to_dict(self) -> dict:
         return {
             "user_id": self.user_id,
-            "access_token": self.access_token,
             "access_token_expires_at": self.access_token_expiration.isoformat(),
         }

--- a/src/api/common/methods.py
+++ b/src/api/common/methods.py
@@ -308,6 +308,7 @@ class WalterAPIMethod(ABC):
         http_status: HTTPStatus,
         status: Status,
         message: str,
+        cookies: Optional[dict] = None,
         data: Optional[dict] = None,
     ) -> Response:
         return Response(
@@ -318,6 +319,7 @@ class WalterAPIMethod(ABC):
             status=status,
             message=message,
             response_time_millis=None,
+            cookies=cookies,
             data=data,
         )
 

--- a/src/api/common/models.py
+++ b/src/api/common/models.py
@@ -67,9 +67,8 @@ class Response:
     data: Optional[dict] = None  # optional data can be included in response
 
     def to_json(self) -> dict:
-        headers = self.HEADERS
-
         # create cookie headers if cookies are included in response
+        multivalue_headers = {}
         if self.cookies is not None:
             cookie_headers = []
             for cookie_name, cookie_value in self.cookies.items():
@@ -85,7 +84,7 @@ class Response:
                         cookie += "; Path=/; HttpOnly; Secure; SameSite=Strict"
 
                 cookie_headers.append(cookie)
-            headers["Set-Cookie"] = cookie_headers
+            multivalue_headers["Set-Cookie"] = cookie_headers
 
         body = {
             "Service": "WalterBackend-API",
@@ -104,11 +103,17 @@ class Response:
         if self.data is not None:
             body["Data"] = self.data
 
-        return {
+        response_json = {
             "statusCode": self.http_status.value,
             "headers": Response.HEADERS,
             "body": json.dumps(body),
         }
+
+        # add optional multivalue headers to response
+        if multivalue_headers:
+            response_json["multiValueHeaders"] = multivalue_headers
+
+        return response_json
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Response):

--- a/src/api/plaid/create_link_token.py
+++ b/src/api/plaid/create_link_token.py
@@ -66,10 +66,10 @@ class CreateLinkToken(WalterAPIMethod):
         user: User = self._verify_user_exists(session.user_id)
         response: CreateLinkTokenResponse = self.plaid.create_link_token(user.user_id)
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Created link token successfully!",
-            response.to_dict(),
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Created link token successfully!",
+            data=response.to_dict(),
         )
 
     def validate_fields(self, event: dict) -> None:

--- a/src/api/plaid/exchange_public_token/method.py
+++ b/src/api/plaid/exchange_public_token/method.py
@@ -136,10 +136,10 @@ class ExchangePublicToken(WalterAPIMethod):
 
         # return successful exchange public token response
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Tokens exchanged successfully!",
-            {
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Tokens exchanged successfully!",
+            data={
                 "institution_id": institution_id,
                 "institution_name": institution_name,
                 "num_accounts": len(accounts),

--- a/src/api/plaid/refresh_transactions.py
+++ b/src/api/plaid/refresh_transactions.py
@@ -75,10 +75,10 @@ class RefreshTransactions(WalterAPIMethod):
             self._refresh_transactions(item)
 
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Transactions refreshed successfully!",
-            {
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Transactions refreshed successfully!",
+            data={
                 "user": user.user_id,
                 "num_items": len(items),
                 "items": [item.get_item_id() for item in items],

--- a/src/api/plaid/sync_transactions.py
+++ b/src/api/plaid/sync_transactions.py
@@ -87,10 +87,10 @@ class SyncTransactions(WalterAPIMethod):
         account: Account = self._verify_account_exists(user_id, account_id)
         self._add_task_to_queue(user_id, account.plaid_item_id)
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Added task to queue!",
-            {
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Added task to queue!",
+            data={
                 "user_id": user.user_id,
                 "account_id": account.account_id,
                 "institution_name": account.institution_name,

--- a/src/api/transactions/add_transaction.py
+++ b/src/api/transactions/add_transaction.py
@@ -115,17 +115,6 @@ class AddTransaction(WalterAPIMethod):
         self.db.add_transaction(transaction)
 
         return self._create_response(
-            HTTPStatus.CREATED,
-            Status.SUCCESS,
-            "Transaction added!",
-            {
-                "transaction": transaction.to_dict(),
-            },
-        )
-        return Response(
-            domain=self.domain,
-            api_name=AddTransaction.API_NAME,
-            request_id=self.request_id,
             http_status=HTTPStatus.CREATED,
             status=Status.SUCCESS,
             message="Transaction added!",

--- a/src/api/transactions/delete_transaction.py
+++ b/src/api/transactions/delete_transaction.py
@@ -80,10 +80,10 @@ class DeleteTransaction(WalterAPIMethod):
         transaction = self._verify_transaction_exists(user, event)
         self._delete_transaction(transaction)
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Transaction deleted!",
-            {"transaction": transaction.to_dict()},
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Transaction deleted!",
+            data={"transaction": transaction.to_dict()},
         )
 
     def validate_fields(self, event: dict) -> None:

--- a/src/api/transactions/edit_transaction.py
+++ b/src/api/transactions/edit_transaction.py
@@ -105,10 +105,10 @@ class EditTransaction(WalterAPIMethod):
         self.db.put_transaction(updated_transaction)
 
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Transaction edited!",
-            {
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Transaction edited!",
+            data={
                 "transaction": updated_transaction.to_dict(),
             },
         )

--- a/src/api/transactions/get_transactions/method.py
+++ b/src/api/transactions/get_transactions/method.py
@@ -106,10 +106,10 @@ class GetTransactions(WalterAPIMethod):
             ]
         )
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Retrieved transactions!",
-            {
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Retrieved transactions!",
+            data={
                 "user_id": user.user_id,
                 "num_transactions": len(transactions),
                 "total_income": total_income,

--- a/src/api/transactions/get_transactions/method.py
+++ b/src/api/transactions/get_transactions/method.py
@@ -217,7 +217,6 @@ class GetTransactions(WalterAPIMethod):
                     if isinstance(transaction, BankTransaction):
                         account_transactions.append(
                             {
-                                "user_id": account.user_id,
                                 "account_id": account.account_id,
                                 "transaction_id": transaction.transaction_id,
                                 "account_institution_name": account.institution_name,

--- a/src/api/users/create_user.py
+++ b/src/api/users/create_user.py
@@ -63,10 +63,10 @@ class CreateUser(WalterAPIMethod):
     def execute(self, event: dict, session: Optional[Session]) -> Response:
         user = self._create_new_user(event)
         return self._create_response(
-            HTTPStatus.CREATED,
-            Status.SUCCESS,
-            "User created!",
-            {
+            http_status=HTTPStatus.CREATED,
+            status=Status.SUCCESS,
+            message="User created!",
+            data={
                 "user_id": user.user_id,
                 "email": user.email,
                 "first_name": user.first_name,

--- a/src/api/users/get_user.py
+++ b/src/api/users/get_user.py
@@ -91,10 +91,10 @@ class GetUser(WalterAPIMethod):
         self.db.update_user(user)
 
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Successfully retrieved user!",
-            {
+            http_status=HTTPStatus.OK,
+            status=Status.SUCCESS,
+            message="Successfully retrieved user!",
+            data={
                 "user_id": user.user_id,
                 "email": user.email,
                 "first_name": user.first_name,

--- a/src/api/users/update_user.py
+++ b/src/api/users/update_user.py
@@ -96,14 +96,6 @@ class UpdateUser(WalterAPIMethod):
         self.db.update_user(user)
 
         return self._create_response(
-            HTTPStatus.OK,
-            Status.SUCCESS,
-            "Updated user!",
-        )
-        return Response(
-            domain=self.domain,
-            api_name=UpdateUser.API_NAME,
-            request_id=self.request_id,
             http_status=HTTPStatus.OK,
             status=Status.SUCCESS,
             message="Updated user!",

--- a/src/canaries/accounts/get_accounts.py
+++ b/src/canaries/accounts/get_accounts.py
@@ -44,6 +44,9 @@ class GetAccounts(BaseCanary):
             headers={"Authorization": f"Bearer {tokens.access_token}"},
         )
 
+    def validate_cookies(self, response: dict) -> None:
+        self._validate_required_response_cookies(response, [])
+
     def validate_data(self, response: dict) -> None:
         LOG.debug("Validating user email in API response data...")
         if response.get("Data", {}).get("user_id", None) is None:

--- a/src/canaries/auth/login.py
+++ b/src/canaries/auth/login.py
@@ -70,15 +70,17 @@ class Login(BaseCanary):
 
         return api_response
 
+    def validate_cookies(self, response: dict) -> None:
+        # validate required cookies in response
+        required_cookies = [
+            "WALTER_BACKEND_ACCESS_TOKEN",
+            "WALTER_BACKEND_REFRESH_TOKEN",
+        ]
+        self._validate_required_response_cookies(response, required_cookies)
+
     def validate_data(self, response: dict) -> None:
         # validate required fields in response data
-        required_fields = [
-            "user_id",
-            "refresh_token",
-            "access_token",
-            "refresh_token_expires_at",
-            "access_token_expires_at",
-        ]
+        required_fields = ["user_id", "refresh_token", "access_token"]
         self._validate_required_response_data_fields(response, required_fields)
 
     def clean_up(self) -> None:

--- a/src/canaries/auth/logout.py
+++ b/src/canaries/auth/logout.py
@@ -38,6 +38,9 @@ class Logout(BaseCanary):
             headers={"Authorization": f"Bearer {tokens.access_token}"},
         )
 
+    def validate_cookies(self, response: dict) -> None:
+        self._validate_required_response_cookies(response, [])
+
     def validate_data(self, response: dict) -> None:
         pass
 

--- a/src/canaries/auth/logout.py
+++ b/src/canaries/auth/logout.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import requests
 from requests import Response
+from requests.cookies import RequestsCookieJar
 
 from src.auth.authenticator import WalterAuthenticator
 from src.auth.models import Tokens
@@ -38,11 +39,18 @@ class Logout(BaseCanary):
             headers={"Authorization": f"Bearer {tokens.access_token}"},
         )
 
-    def validate_cookies(self, response: dict) -> None:
-        self._validate_required_response_cookies(response, [])
+    def validate_cookies(self, cookies: RequestsCookieJar) -> None:
+        required_cookies = []
+        self._validate_required_response_cookies(cookies, required_cookies)
 
-    def validate_data(self, response: dict) -> None:
-        pass
+    def validate_data(self, data: dict) -> None:
+        required_fields = [
+            ("user_id", None),
+            ("session_id", None),
+            ("session_start", None),
+            ("session_end", None),
+        ]
+        self._validate_required_response_data_fields(data, required_fields)
 
     def clean_up(self) -> None:
         LOG.info(f"No resources to clean up after '{self.API_NAME}' canary!")

--- a/src/canaries/auth/refresh.py
+++ b/src/canaries/auth/refresh.py
@@ -37,6 +37,9 @@ class Refresh(BaseCanary):
             Refresh.API_URL, headers={"Authorization": f"Bearer {tokens.refresh_token}"}
         )
 
+    def validate_cookies(self, response: dict) -> None:
+        self._validate_required_response_cookies(response, [])
+
     def validate_data(self, response: dict) -> None:
         # validate response data exists
         data = BaseCanary.validate_response_data(response)

--- a/src/canaries/auth/refresh.py
+++ b/src/canaries/auth/refresh.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import requests
 from requests import Response
+from requests.cookies import RequestsCookieJar
 
 from src.auth.authenticator import WalterAuthenticator
 from src.auth.models import Tokens
@@ -37,16 +38,15 @@ class Refresh(BaseCanary):
             Refresh.API_URL, headers={"Authorization": f"Bearer {tokens.refresh_token}"}
         )
 
-    def validate_cookies(self, response: dict) -> None:
-        self._validate_required_response_cookies(response, [])
+    def validate_cookies(self, cookies: RequestsCookieJar) -> None:
+        required_cookies = [
+            "WALTER_BACKEND_ACCESS_TOKEN",
+        ]
+        self._validate_required_response_cookies(cookies, required_cookies)
 
-    def validate_data(self, response: dict) -> None:
-        # validate response data exists
-        data = BaseCanary.validate_response_data(response)
-
-        # validate required fields in response data
-        for field in ["user_id", "access_token", "access_token_expires_at"]:
-            BaseCanary.validate_required_field(data, field)
+    def validate_data(self, data: dict) -> None:
+        required_fields = [("user_id", None), ("access_token_expires_at", None)]
+        self._validate_required_response_data_fields(data, required_fields)
 
     def clean_up(self) -> None:
         LOG.info(f"No resources to clean up after '{self.API_NAME}' canary!")

--- a/src/canaries/transactions/get_transactions.py
+++ b/src/canaries/transactions/get_transactions.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import requests
 from requests import Response
+from requests.cookies import RequestsCookieJar
 
 from src.auth.authenticator import WalterAuthenticator
 from src.auth.models import Tokens
@@ -50,47 +51,96 @@ class GetTransactions(BaseCanary):
             headers={"Authorization": f"Bearer {tokens.access_token}"},
         )
 
-    def validate_cookies(self, response: dict) -> None:
-        self._validate_required_response_cookies(response, [])
+    def validate_cookies(self, cookies: RequestsCookieJar) -> None:
+        required_cookies = []
+        self._validate_required_response_cookies(cookies, required_cookies)
 
-    def validate_data(self, response: dict) -> None:
+    def validate_data(self, data: dict) -> None:
         # canary transaction details
         expected_num_transactions = 3
         expected_total_income = 00.00
         expected_total_expense = 105.00
         expected_cash_flow = -105.00
 
-        # validate response data exists and is valid
-        data = BaseCanary.validate_response_data(response)
-        for field, value in {
-            "user_id": None,
-            "num_transactions": expected_num_transactions,
-            "total_income": expected_total_income,
-            "total_expense": expected_total_expense,
-            "cash_flow": expected_cash_flow,
-            "transactions": None,
-        }.items():
-            BaseCanary.validate_required_field(data, field, value)
+        required_fields = [
+            ("user_id", None),
+            ("num_transactions", expected_num_transactions),
+            ("total_income", expected_total_income),
+            ("total_expense", expected_total_expense),
+            ("cash_flow", expected_cash_flow),
+            ("transactions", None),
+        ]
+        self._validate_required_response_data_fields(data, required_fields)
 
         # assert expected number of transactions are returned
-        transactions = data["transactions"]
+        transactions = data["Data"]["transactions"]
         if len(transactions) != expected_num_transactions:
             raise CanaryFailure(
                 f"Expected {expected_num_transactions} transactions in response!"
             )
 
-        # assert transactions returned in response are valid in format
+        required_transactions = {
+            "bank-txn-7015884840": [
+                ("account_id", "acct-5782898837"),
+                ("transaction_id", "bank-txn-7015884840"),
+                ("account_institution_name", "Canary Bank"),
+                ("account_name", "Canary Credit Account"),
+                ("account_type", "credit"),
+                ("account_mask", "2222"),
+                ("transaction_type", "banking"),
+                ("transaction_subtype", "debit"),
+                ("transaction_category", "Restaurants"),
+                ("transaction_date", "2025-08-01"),
+                ("merchant_name", "Canary Coffee"),
+                ("transaction_amount", 5.0),
+            ],
+            "bank-txn-7016361254": [
+                ("account_id", "acct-5782898837"),
+                ("transaction_id", "bank-txn-7016361254"),
+                ("account_institution_name", "Canary Bank"),
+                ("account_name", "Canary Credit Account"),
+                ("account_type", "credit"),
+                ("account_mask", "2222"),
+                ("transaction_type", "banking"),
+                ("transaction_subtype", "debit"),
+                ("transaction_category", "Entertainment"),
+                ("transaction_date", "2025-08-01"),
+                ("merchant_name", "Canary Concert Tickets"),
+                ("transaction_amount", 100.0),
+            ],
+            "investment-txn-7017568759": [
+                ("account_id", "acct-5782388299"),
+                ("transaction_id", "investment-txn-7017568759"),
+                ("security_id", "sec-nasdaq-amzn"),
+                ("account_institution_name", "Canary Investing"),
+                ("account_name", "Canary Retirement Account"),
+                ("account_type", "investment"),
+                ("account_mask", "1111"),
+                ("transaction_date", "2025-08-01"),
+                ("transaction_type", "investment"),
+                ("transaction_subtype", "buy"),
+                ("transaction_category", "Investment"),
+                ("price_per_share", 100.0),
+                ("quantity", 10.0),
+                ("transaction_amount", 1000.0),
+            ],
+        }
+
         for transaction in transactions:
-            for field in [
-                "account_id",
-                "transaction_id",
-                "transaction_date",
-                "transaction_type",
-                "transaction_subtype",
-                "transaction_category",
-                "transaction_amount",
-            ]:
-                BaseCanary.validate_required_field(transaction, field)
+            if "transaction_id" not in transaction:
+                raise CanaryFailure(
+                    f"Missing 'transaction_id' in transaction: {transaction}"
+                )
+
+            if transaction["transaction_id"] not in required_transactions:
+                raise CanaryFailure(
+                    f"Unexpected transaction returned in response: {transaction}"
+                )
+
+            expected_transaction = required_transactions[transaction["transaction_id"]]
+            self._validate_required_response_data_fields(
+                transaction, expected_transaction
+            )
 
     def clean_up(self) -> None:
         LOG.info(f"No resources to clean up after '{self.CANARY_NAME}' canary!")

--- a/src/canaries/transactions/get_transactions.py
+++ b/src/canaries/transactions/get_transactions.py
@@ -50,6 +50,9 @@ class GetTransactions(BaseCanary):
             headers={"Authorization": f"Bearer {tokens.access_token}"},
         )
 
+    def validate_cookies(self, response: dict) -> None:
+        self._validate_required_response_cookies(response, [])
+
     def validate_data(self, response: dict) -> None:
         # canary transaction details
         expected_num_transactions = 3

--- a/src/canaries/users/create_user.py
+++ b/src/canaries/users/create_user.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import requests
 from requests import Response
+from requests.cookies import RequestsCookieJar
 
 from src.auth.authenticator import WalterAuthenticator
 from src.auth.models import Tokens
@@ -56,26 +57,20 @@ class CreateUser(BaseCanary):
             },
         )
 
-    def validate_cookies(self, response: dict) -> None:
-        self._validate_required_response_cookies(response, [])
+    def validate_cookies(self, cookies: RequestsCookieJar) -> None:
+        required_cookies = []
+        self._validate_required_response_cookies(cookies, required_cookies)
 
     def validate_data(self, response: dict) -> None:
-        # validate response includes data
-        data = BaseCanary.validate_response_data(response)
-
-        # validate response data includes the required fields with
-        # asserted values if applicable
-        required_data_fields = [
+        required_fields = [
             ("user_id", None),
-            ("email", self.NEW_USER_EMAIL),
-            ("first_name", self.NEW_USER_FIRST_NAME),
-            ("last_name", self.NEW_USER_LAST_NAME),
+            ("email", None),
+            ("first_name", None),
+            ("last_name", None),
             ("sign_up_date", None),
-            ("verified", False),
+            ("verified", None),
         ]
-        for field in required_data_fields:
-            field_name, field_value = field
-            BaseCanary.validate_required_field(data, field_name, field_value)
+        self._validate_required_response_data_fields(response, required_fields)
 
     def clean_up(self) -> None:
         LOG.info(f"Cleaning up after '{self.CANARY_NAME}' canary!")

--- a/src/canaries/users/create_user.py
+++ b/src/canaries/users/create_user.py
@@ -56,6 +56,9 @@ class CreateUser(BaseCanary):
             },
         )
 
+    def validate_cookies(self, response: dict) -> None:
+        self._validate_required_response_cookies(response, [])
+
     def validate_data(self, response: dict) -> None:
         # validate response includes data
         data = BaseCanary.validate_response_data(response)

--- a/src/canaries/users/get_user.py
+++ b/src/canaries/users/get_user.py
@@ -46,6 +46,9 @@ class GetUser(BaseCanary):
             headers={"Authorization": f"Bearer {tokens.access_token}"},
         )
 
+    def validate_cookies(self, response: dict) -> None:
+        self._validate_required_response_cookies(response, [])
+
     def validate_data(self, response: dict) -> None:
         data = BaseCanary.validate_response_data(response)
         BaseCanary.validate_required_field(data, "user_id")

--- a/src/canaries/users/get_user.py
+++ b/src/canaries/users/get_user.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import requests
 from requests import Response
+from requests.cookies import RequestsCookieJar
 
 from src.auth.authenticator import WalterAuthenticator
 from src.auth.models import Tokens
@@ -46,13 +47,23 @@ class GetUser(BaseCanary):
             headers={"Authorization": f"Bearer {tokens.access_token}"},
         )
 
-    def validate_cookies(self, response: dict) -> None:
-        self._validate_required_response_cookies(response, [])
+    def validate_cookies(self, cookies: RequestsCookieJar) -> None:
+        required_cookies = []
+        self._validate_required_response_cookies(cookies, required_cookies)
 
     def validate_data(self, response: dict) -> None:
-        data = BaseCanary.validate_response_data(response)
-        BaseCanary.validate_required_field(data, "user_id")
-        BaseCanary.validate_required_field(data, "email", self.CANARY_USER_EMAIL)
+        required_fields = [
+            ("user_id", None),
+            ("email", None),
+            ("first_name", None),
+            ("last_name", None),
+            ("verified", None),
+            ("sign_up_date", None),
+            ("last_active_date", None),
+            ("profile_picture_url", None),
+            ("active_stripe_subscription", None),
+        ]
+        self._validate_required_response_data_fields(response, required_fields)
 
     def clean_up(self) -> None:
         LOG.info(f"No resources to clean up after '{self.CANARY_NAME}' canary!")

--- a/src/factory.py
+++ b/src/factory.py
@@ -74,7 +74,8 @@ class ClientFactory:
             ),
             domain=self.domain,
         ).get_caller_identity()
-        LOG.info(f"Set AWS credentials to role '{credentials_role_arn}'")
+        principal = "/".join(credentials_role_arn.split("/")[1:])
+        LOG.info(f"Set AWS credentials to principal '{principal}'")
 
     def get_aws_region(self) -> str:
         return self.region
@@ -160,7 +161,8 @@ class ClientFactory:
                 domain=self.domain,
             )
             role_arn: str = self.sts.get_caller_identity()
-            LOG.info(f"Created STS client with credentials for role '{role_arn}'")
+            principal = role_arn.split(":")[5].split("/")[1]
+            LOG.info(f"Created STS client with credentials for principal '{principal}'")
         return self.sts
 
     def get_authenticator(self) -> WalterAuthenticator:

--- a/tst/api/auth/test_login.py
+++ b/tst/api/auth/test_login.py
@@ -51,11 +51,15 @@ def test_login_success(
 
     response = login_api.invoke(event)
 
+    cookies = []
+    for cookie in response.cookies:
+        cookies.append(cookie.split(";")[0].split("=")[0])
+
     assert response.http_status == HTTPStatus.OK
     assert response.status == Status.SUCCESS
     assert response.message == "User logged in successfully!"
-    assert "access_token" in response.data
-    assert "refresh_token" in response.data
+    assert "WALTER_BACKEND_ACCESS_TOKEN" in cookies
+    assert "WALTER_BACKEND_REFRESH_TOKEN" in cookies
     assert "access_token_expires_at" in response.data
     assert "refresh_token_expires_at" in response.data
     assert response.data["user_id"] == walter_db.get_user_by_email(email).user_id

--- a/tst/api/auth/test_refresh.py
+++ b/tst/api/auth/test_refresh.py
@@ -28,33 +28,24 @@ def test_refresh_success(
     walter_authenticator: WalterAuthenticator,
     walter_db: WalterDB,
 ) -> None:
-    # Arrange: create a session matching a generated refresh token
     user_id = "user-001"
     tokens = walter_authenticator.generate_tokens(user_id)
-
-    # Create a session with the JTI from tokens
     walter_db.create_session(
         user_id=user_id,
         token_id=tokens.jti,
         ip_address="127.0.0.1",
         device="pytest/1.0",
     )
-
     event = get_api_event(
         REFRESH_API_PATH,
         REFRESH_API_METHOD,
         token=tokens.refresh_token,
     )
-
-    # Act
     response = refresh_api.invoke(event)
-
-    # Assert
     assert response.http_status == HTTPStatus.OK
     assert response.status == Status.SUCCESS
     assert response.message == "Access token refreshed!"
     assert "user_id" in response.data
-    assert "access_token" in response.data
     assert "access_token_expires_at" in response.data
 
 


### PR DESCRIPTION
## Summary

This PR ensures that cookies are set/unset securely via the `/auth` API's.

TIL that cookies can be set by the backend directly via the `Set-Cookie` header. This header has a special format that lets you adhere to certain rules as well such as `Path`, `HttpOnly`, `Secure`, `SameSite`, and more. These rules essentially tell the browser how to handle the authentication cookies when it receives them.

This lets `WalterBackend` control the setting/unsetting and security of the authentication tokens - which are highly critically because its what the browser uses to make authenticated requests on behalf of the user.

So, this PR refactors `WalterBackend` to pass the cookies as `multiValueHeaders` with varying degrees of security based on the domain. For example, when the domain is prod, the rule `Secure` and `SameSite=Strict` is applied to ensure that only the frontend call call the backed via an HTTPS connection.

This PR is part of a larger effort to improve security for `WalterBackend`

## Context

This ensures that `WalterBackend` informs browsers how to securely handle its auth cookies. This is necessary for a highly secure design. 

## Changes

- Set auth cookies via API response headers with varying degrees of security given the service domain
- Updated canaries validate APIs that return cookies such as the `Login` and `Refresh` APIs

## Testing

Deployed to development and E2E testing with `curl`.

## Notes

N/A
