### PR TITLE
feat: add ttl to unexpired sessions

### DIFF
--- a/src/database/sessions/models.py
+++ b/src/database/sessions/models.py
@@ -46,17 +46,19 @@ class Session:
         device: str,
     ) -> "Session":
         now = datetime.now(timezone.utc)
+        # TODO: This should stay in sync with refresh token expiry
+        session_expiration = now + timedelta(days=7)
+        # TODO: This should be a config value
+        ttl = session_expiration + timedelta(days=7)
         return Session(
             user_id=user_id,
             token_id=token_id,
             ip_address=ip_address,
             device=device,
             session_start=now,
-            session_expiration=now
-            + timedelta(
-                days=7
-            ),  # TODO: This should stay in sync with refresh token expiry
+            session_expiration=session_expiration,
             revoked=False,
+            ttl=int(ttl.timestamp()),
         )
 
     @classmethod


### PR DESCRIPTION
## Summary

This PR adds a `ttl` value to newly created (or unexpired) sessions in the database. This ensures that even sessions that were never revoked (i.e. the user never logged out) still have a reasonable `ttl` value in the database that ensures the record will eventually be cleaned up.

This just helps to make sure the database isn't storing a bunch of old session data with no use. Saving a week to a few months worth of session data is reasonable as you can show the user their past usage but beyond that just takes up space in the db. 

Also, sessions are created incredibly frequently so its important `WalterBackend` implements proper handling.

## Context

Ensures the database is not filled with old, unexpired sessions without a `ttl`

## Changes

- Add `ttl` to Sessions table items to enforce DynamoDB pruning.

## Testing

- E2E testing in `dev`

## Notes

N/A