### PR TITLE
feat: add vpc network

### DIFF
--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -3,9 +3,10 @@
  ***********************/
 
 # WalterAI dev account details
-account_id = "010526272437"
-region     = "us-east-1"
-domain     = "dev"
+account_id        = "010526272437"
+region            = "us-east-1"
+availability_zone = "us-east-1a"
+domain            = "dev"
 
 # WalterBackend application version
 walter_backend_version = "0.0.0"
@@ -18,6 +19,11 @@ log_retention_in_days = 7
 
 # walterai.dev Route53 hosted zone ID
 hosted_zone_id = "Z06872281VCZDG3SK2QXB"
+
+# WalterBackend Network settings
+network_cidr        = "10.0.0.0/27"
+public_subnet_cidr  = "10.0.0.0/28"
+private_subnet_cidr = "10.0.0.16/28"
 
 # WalterBackend API settings
 api_timeout_seconds                   = 15

--- a/infra/infrastructure/functions.tf
+++ b/infra/infrastructure/functions.tf
@@ -87,6 +87,8 @@ module "functions" {
   provisioned_concurrent_executions = each.value.provisioned_concurrent_executions
   alias_name                        = "release"
   function_version                  = each.value.function_version
+  security_group_ids                = [module.network.function_sg_id]
+  subnet_ids                        = [module.network.private_subnet_id]
 }
 
 /************************************

--- a/infra/infrastructure/modules/iam_lambda_execution_role/main.tf
+++ b/infra/infrastructure/modules/iam_lambda_execution_role/main.tf
@@ -16,9 +16,9 @@ resource "aws_iam_role" "this" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "basic_execution" {
+resource "aws_iam_role_policy_attachment" "vpc_execution" {
   role       = aws_iam_role.this.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy_attachment" "additional_policies" {

--- a/infra/infrastructure/modules/lamdba_function/main.tf
+++ b/infra/infrastructure/modules/lamdba_function/main.tf
@@ -20,6 +20,11 @@ resource "aws_lambda_function" "this" {
   memory_size   = var.memory_size
   architectures = ["arm64"]
 
+  vpc_config {
+    security_group_ids = var.security_group_ids
+    subnet_ids         = var.subnet_ids
+  }
+
   environment {
     variables = {
       DD_LAMBDA_HANDLER = var.lambda_handler
@@ -77,4 +82,9 @@ resource "aws_kms_key" "env_vars_kms_key" {
       }
     ]
   })
+}
+
+resource "aws_kms_alias" "env_vars_kms_key_alias" {
+  name          = "alias/${var.function_name}"
+  target_key_id = aws_kms_key.env_vars_kms_key.id
 }

--- a/infra/infrastructure/modules/lamdba_function/variables.tf
+++ b/infra/infrastructure/modules/lamdba_function/variables.tf
@@ -81,3 +81,13 @@ variable "function_version" {
   description = "The version of the Lambda function."
   type        = string
 }
+
+variable "security_group_ids" {
+  description = "List of security group IDs to associate with the Lambda function."
+  type        = list(string)
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs to associate with the Lambda function."
+  type        = list(string)
+}

--- a/infra/infrastructure/modules/vpc_network/main.tf
+++ b/infra/infrastructure/modules/vpc_network/main.tf
@@ -1,0 +1,130 @@
+locals {
+  # Capture "us-east-1" and "a"
+  az_parts = regex("^(.*[0-9])([a-z])$", var.availability_zone)
+
+  region_abbreviations = {
+    "us-east-1"      = "USE1"
+    "us-east-2"      = "USE2"
+    "us-west-1"      = "USW1"
+    "us-west-2"      = "USW2"
+    "ca-central-1"   = "CAC1"
+    "eu-central-1"   = "EUC1"
+    "eu-west-1"      = "EUW1"
+    "eu-west-2"      = "EUW2"
+    "eu-west-3"      = "EUW3"
+    "ap-south-1"     = "APS1"
+    "ap-northeast-1" = "APNE1"
+    "ap-northeast-2" = "APNE2"
+    "ap-northeast-3" = "APNE3"
+    "ap-southeast-1" = "APSE1"
+    "ap-southeast-2" = "APSE2"
+    "sa-east-1"      = "SAE1"
+  }
+
+  az_short = format(
+    "%s%s",
+    lookup(local.region_abbreviations, local.az_parts[0], upper(local.az_parts[0])),
+    upper(local.az_parts[1])
+  )
+}
+
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags                 = { Name = "${var.name}-VPC-${var.domain}" }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = { Name = "${var.name}-IGW-${var.domain}" }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
+  tags                    = { Name = "${var.name}-PublicSubnet-${local.az_short}-${var.domain}" }
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidr
+  availability_zone = var.availability_zone
+  tags              = { Name = "${var.name}-PrivateSubnet-${local.az_short}-${var.domain}" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  tags   = { Name = "${var.name}-PublicRouteTable-${var.domain}" }
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public_assoc" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+  tags   = { Name = "${var.name}-NATGW-EIP-${var.domain}" }
+
+  depends_on = [
+    aws_internet_gateway.this
+  ]
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public.id
+  tags          = { Name = "${var.name}-NATGW-${var.domain}" }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+  tags   = { Name = "${var.name}-PrivateRouteTable-${var.domain}" }
+}
+
+resource "aws_route" "private_nat_gateway" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this.id
+}
+
+resource "aws_route_table_association" "private_assoc" {
+  subnet_id      = aws_subnet.private.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_security_group" "function_sg" {
+  name        = "${var.name}-Function-SG-${var.domain}"
+  description = "The security group for WalterBackend functions. (${var.domain}) "
+  vpc_id      = aws_vpc.this.id
+
+  # Lambda needs outbound access to NAT Gateway / Internet
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # No inbound rules needed for API Gateway
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = []
+  }
+
+  tags = {
+    Name = "${var.name}-Function-SG-${var.domain}"
+  }
+}

--- a/infra/infrastructure/modules/vpc_network/outputs.tf
+++ b/infra/infrastructure/modules/vpc_network/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_id" {
+  value = aws_subnet.public.id
+}
+
+output "private_subnet_id" {
+  value = aws_subnet.private.id
+}
+
+output "nat_gateway_id" {
+  value = aws_nat_gateway.this.id
+}
+
+output "function_sg_id" {
+  value = aws_security_group.function_sg.id
+}

--- a/infra/infrastructure/modules/vpc_network/variables.tf
+++ b/infra/infrastructure/modules/vpc_network/variables.tf
@@ -1,0 +1,42 @@
+variable "domain" {
+  description = "The domain of WalterBackend."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "stg", "prod"], var.domain)
+    error_message = "The domain must be 'dev', 'stg', or 'prod'."
+  }
+}
+
+variable "name" {
+  description = "The name of the VPC."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block of the VPC."
+  type        = string
+}
+
+variable "public_subnet_cidr" {
+  description = "The CIDR block of the public subnet."
+  type        = string
+}
+
+variable "private_subnet_cidr" {
+  description = "The CIDR block of the private subnet."
+  type        = string
+}
+
+variable "availability_zone" {
+  description = "The availability zone to use."
+  type        = string
+
+  validation {
+    condition     = startswith(var.availability_zone, data.aws_region.current.name)
+    error_message = "The availability_zone must start with the current AWS region (e.g., us-east-1a if region is us-east-1)."
+  }
+}
+
+# Look up the current region from AWS credentials / provider
+data "aws_region" "current" {}

--- a/infra/infrastructure/network.tf
+++ b/infra/infrastructure/network.tf
@@ -1,0 +1,13 @@
+/*************************
+ * WalterBackend Network *
+ *************************/
+
+module "network" {
+  source              = "./modules/vpc_network"
+  name                = "WalterBackend"
+  domain              = var.domain
+  vpc_cidr            = var.network_cidr
+  availability_zone   = var.availability_zone
+  public_subnet_cidr  = var.public_subnet_cidr
+  private_subnet_cidr = var.private_subnet_cidr
+}

--- a/infra/infrastructure/variables.tf
+++ b/infra/infrastructure/variables.tf
@@ -62,6 +62,26 @@ variable "log_retention_in_days" {
   }
 }
 
+variable "network_cidr" {
+  description = "The CIDR block of the WalterBackend network."
+  type        = string
+}
+
+variable "availability_zone" {
+  description = "The availability zone of the public and private subnets."
+  type        = string
+}
+
+variable "public_subnet_cidr" {
+  description = "The CIDR block of the WalterBackend public subnet."
+  type        = string
+}
+
+variable "private_subnet_cidr" {
+  description = "The CIDR block of the WalterBackend private subnet."
+  type        = string
+}
+
 variable "api_function_version" {
   description = "The WalterBackend-API Lambda function version to use for API requests."
   type        = number


### PR DESCRIPTION
## Summary

This PR adds a VPC network to `WalterBackend`. 

This is a security improvement as it allows for granular control over the networking of `WalterBackend`.

For example, all functions are now in private subnets without access to the internet so that only API Gateway can invoke the functions. For external API calls, there exists a NAT Gateway to help translate outbound internet connections.

Adding a VPC network also allows for more strict network control via security groups. 

## Context

`WalterBackend` is a personal finance application, it should be incredibly secure with non-publicly accessible Lambda functions

## Changes

- [ X] Lambda functions are in private subnets with outbound internet access via NAT and SGs
- [ X] Lambda functions communicate with WalterDB and DynamoDB via VPC endpoint to reduce NAT Gateway costs and improve security
- [X] WalterDB DynamoDB access restricted to VPC endpoint to ensure only entities able to communicate with database directly are the Lambda functions

## Testing

- E2E testing in the `dev` environment

## Notes

N/A
