### PR TITLE
feat: add dynamodb and secrets manager vpc endpoints

### DIFF
--- a/infra/infrastructure/modules/vpc_network/main.tf
+++ b/infra/infrastructure/modules/vpc_network/main.tf
@@ -128,3 +128,29 @@ resource "aws_security_group" "function_sg" {
     Name = "${var.name}-Function-SG-${var.domain}"
   }
 }
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id            = aws_vpc.this.id
+  service_name      = "com.amazonaws.${var.region}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+
+  # Associate with the private route table so private subnets can reach DynamoDB
+  route_table_ids = [aws_route_table.private.id]
+
+  tags = {
+    Name = "${var.name}-VPCE-DynamoDB-${var.domain}"
+  }
+}
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.region}.secretsmanager"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [aws_subnet.private.id]
+  security_group_ids  = [aws_security_group.function_sg.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.name}-VPCE-SecretsManager-${var.domain}"
+  }
+}

--- a/infra/infrastructure/modules/vpc_network/variables.tf
+++ b/infra/infrastructure/modules/vpc_network/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  description = "The region of WalterBackend."
+  type        = string
+}
+
 variable "domain" {
   description = "The domain of WalterBackend."
   type        = string

--- a/infra/infrastructure/network.tf
+++ b/infra/infrastructure/network.tf
@@ -5,6 +5,7 @@
 module "network" {
   source              = "./modules/vpc_network"
   name                = "WalterBackend"
+  region              = var.region
   domain              = var.domain
   vpc_cidr            = var.network_cidr
   availability_zone   = var.availability_zone


### PR DESCRIPTION
## Summary

This PR adds DynamoDB and SecretsManager VPC endpoints addressable in the private subnets.

This ensures that resources, such as the functions, deployed in the private subnets can access these AWS services without leaving the internal AWS network via the NAT gateway. 

This ultimately saves costs as NAT Gateways charge in part due to amount of data transferred and this is a security improvement as it keeps more traffic within AWS' network.

## Context

This ensures that private subnet resources can access DynamoDB and SecretsManager without leaving AWS' network

## Changes

- [X] Create DynamoDB and SecretsManager VPC endpoints and add to private subnets

## Testing

E2E testing in `dev`

## Notes

N/A
