### PR TITLE
fix: update readme again

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Walter combines automation and intelligence to help you spend smarter, save fast
 
 ### Architecture
 
-![walter-backend-arch-diagram](https://github.com/user-attachments/assets/53243c49-7b86-4e87-b354-82108cfcca68)
+![walter-backend-architecture-diagram](https://github.com/user-attachments/assets/75a99b3b-a1d7-4399-b0af-ec7a4c9510f7)
+
 
 ## API Documentation
 


### PR DESCRIPTION
## Summary

The exported dark mode format of the new arch diagram looked bad.

Retrying arch diagram update after exporting with white background...

## Context

Because documentation is important I guess...

## Changes

- [X] Exported arch diagram with white background to fix visual formatting issues with `README.md`

## Testing

Reviewed preview in web editor this time to ensure it looked good after formatting ahead of merge.

## Notes

N/A
