### PR TITLE
feat: separate db access by read, write, delete permissions

### DIFF
--- a/infra/infrastructure/api.tf
+++ b/infra/infrastructure/api.tf
@@ -164,7 +164,9 @@ locals {
         module.holdings_table.table_arn,
         module.securities_table.table_arn
       ]
-      write_access_table_arns  = []
+      write_access_table_arns = [
+        module.accounts_table.table_arn
+      ]
       delete_access_table_arns = []
     }
 

--- a/infra/infrastructure/api.tf
+++ b/infra/infrastructure/api.tf
@@ -63,10 +63,15 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.users_table.table_name,
-        module.sessions_table.table_name
+      read_access_table_arns = [
+        module.users_table.table_arn,
+        module.sessions_table.table_arn
       ]
+      write_access_table_arns = [
+        module.users_table.table_arn,
+        module.sessions_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     logout = {
@@ -75,10 +80,15 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.users_table.table_name,
-        module.sessions_table.table_name
+      read_access_table_arns = [
+        module.users_table.table_arn,
+        module.sessions_table.table_arn
       ]
+      write_access_table_arns = [
+        module.users_table.table_arn,
+        module.sessions_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     refresh = {
@@ -87,10 +97,15 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.users_table.table_name,
-        module.sessions_table.table_name
+      read_access_table_arns = [
+        module.users_table.table_arn,
+        module.sessions_table.table_arn
       ]
+      write_access_table_arns = [
+        module.users_table.table_arn,
+        module.sessions_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     get_user = {
@@ -99,28 +114,41 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.users_table.table_name,
-        module.sessions_table.table_name
+      read_access_table_arns = [
+        module.users_table.table_arn,
+        module.sessions_table.table_arn
       ]
+      write_access_table_arns = [
+        module.users_table.table_arn,
+        module.sessions_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     create_user = {
       name        = "CreateUser"
       description = "The role used by the WalterBackend API function to execute the CreateUser API. (${var.domain})"
       secrets     = []
-      tables = [
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.users_table.table_arn
       ]
+      write_access_table_arns = [
+        module.users_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     update_user = {
       name        = "UpdateUser"
       description = "The role used by the WalterBackend API function to execute the UpdateUser API. (${var.domain})"
       secrets     = []
-      tables = [
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.users_table.table_arn
       ]
+      write_access_table_arns = [
+        module.users_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     get_accounts = {
@@ -129,13 +157,15 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.accounts_table.table_name,
-        module.sessions_table.table_name,
-        module.users_table.table_name,
-        module.holdings_table.table_name,
-        module.securities_table.table_name
+      read_access_table_arns = [
+        module.accounts_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn,
+        module.holdings_table.table_arn,
+        module.securities_table.table_arn
       ]
+      write_access_table_arns  = []
+      delete_access_table_arns = []
     }
 
     create_account = {
@@ -144,11 +174,17 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.accounts_table.table_name,
-        module.sessions_table.table_name,
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.accounts_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
       ]
+      write_access_table_arns = [
+        module.accounts_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     update_account = {
@@ -157,11 +193,17 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.accounts_table.table_name,
-        module.sessions_table.table_name,
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.accounts_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
       ]
+      write_access_table_arns = [
+        module.accounts_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     delete_account = {
@@ -170,10 +212,14 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.accounts_table.table_name,
-        module.sessions_table.table_name,
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.accounts_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
+      ]
+      write_access_table_arns = []
+      delete_access_table_arns = [
+        module.accounts_table.table_arn,
       ]
     }
 
@@ -183,14 +229,16 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.sessions_table.table_name,
-        module.accounts_table.table_name,
-        module.users_table.table_name,
-        module.holdings_table.table_name,
-        module.securities_table.table_name,
-        module.transactions_table.table_name,
+      read_access_table_arns = [
+        module.sessions_table.table_arn,
+        module.accounts_table.table_arn,
+        module.users_table.table_arn,
+        module.holdings_table.table_arn,
+        module.securities_table.table_arn,
+        module.transactions_table.table_arn,
       ]
+      write_access_table_arns  = []
+      delete_access_table_arns = []
     }
 
     add_transaction = {
@@ -199,11 +247,15 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.transactions_table.table_name,
-        module.sessions_table.table_name,
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.transactions_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
       ]
+      write_access_table_arns = [
+        module.transactions_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     edit_transaction = {
@@ -212,11 +264,15 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.transactions_table.table_name,
-        module.sessions_table.table_name,
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.transactions_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
       ]
+      write_access_table_arns = [
+        module.transactions_table.table_arn,
+      ]
+      delete_access_table_arns = []
     }
 
     delete_transaction = {
@@ -225,10 +281,14 @@ locals {
       secrets = [
         module.secrets["Auth"].secret_name
       ]
-      tables = [
-        module.transactions_table.table_name,
-        module.sessions_table.table_name,
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.transactions_table.table_arn,
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
+      ]
+      write_access_table_arns = []
+      delete_access_table_arns = [
+        module.transactions_table.table_arn
       ]
     }
 
@@ -239,10 +299,15 @@ locals {
         module.secrets["Auth"].secret_name,
         module.secrets["Plaid"].secret_name
       ]
-      tables = [
-        module.sessions_table.table_name,
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
       ]
+      write_access_table_arns = [
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
 
     exchange_public_token = {
@@ -252,9 +317,17 @@ locals {
         module.secrets["Auth"].secret_name,
         module.secrets["Plaid"].secret_name
       ]
-      tables = [
-        module.sessions_table.table_name,
-        module.users_table.table_name
+      read_access_table_arns = [
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
+      ]
+      write_access_table_arns = [
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
+      ]
+      delete_access_table_arns = [
+        module.sessions_table.table_arn,
+        module.users_table.table_arn
       ]
     }
 
@@ -265,11 +338,17 @@ locals {
         module.secrets["Auth"].secret_name,
         module.secrets["Plaid"].secret_name
       ]
-      tables = [
-        module.sessions_table.table_name,
-        module.users_table.table_name,
-        module.transactions_table.table_name
+      read_access_table_arns = [
+        module.sessions_table.table_arn,
+        module.users_table.table_arn,
+        module.transactions_table.table_arn
       ]
+      write_access_table_arns = [
+        module.sessions_table.table_arn,
+        module.users_table.table_arn,
+        module.transactions_table.table_arn
+      ]
+      delete_access_table_arns = []
     }
   }
 }
@@ -411,7 +490,9 @@ module "api_roles" {
   name                       = each.value.name
   description                = each.value.description
   secret_names               = each.value.secrets
-  table_names                = each.value.tables
+  read_table_access_arns     = each.value.read_access_table_arns
+  write_table_access_arns    = each.value.write_access_table_arns
+  delete_table_access_arns   = each.value.delete_access_table_arns
   api_base_role              = module.api_base_role.arn
   assume_api_role_principals = var.api_assume_role_additional_principals
 }

--- a/infra/infrastructure/api.tf
+++ b/infra/infrastructure/api.tf
@@ -71,7 +71,8 @@ locals {
         module.users_table.table_arn,
         module.sessions_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     logout = {
@@ -88,7 +89,8 @@ locals {
         module.users_table.table_arn,
         module.sessions_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     refresh = {
@@ -105,7 +107,8 @@ locals {
         module.users_table.table_arn,
         module.sessions_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     get_user = {
@@ -122,7 +125,8 @@ locals {
         module.users_table.table_arn,
         module.sessions_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     create_user = {
@@ -135,7 +139,8 @@ locals {
       write_access_table_arns = [
         module.users_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     update_user = {
@@ -148,7 +153,8 @@ locals {
       write_access_table_arns = [
         module.users_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     get_accounts = {
@@ -167,7 +173,8 @@ locals {
       write_access_table_arns = [
         module.accounts_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     create_account = {
@@ -186,7 +193,8 @@ locals {
         module.sessions_table.table_arn,
         module.users_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     update_account = {
@@ -205,7 +213,8 @@ locals {
         module.sessions_table.table_arn,
         module.users_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     delete_account = {
@@ -223,6 +232,7 @@ locals {
       delete_access_table_arns = [
         module.accounts_table.table_arn,
       ]
+      send_message_access_queue_arns = []
     }
 
     get_transactions = {
@@ -239,8 +249,9 @@ locals {
         module.securities_table.table_arn,
         module.transactions_table.table_arn,
       ]
-      write_access_table_arns  = []
-      delete_access_table_arns = []
+      write_access_table_arns        = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     add_transaction = {
@@ -257,7 +268,8 @@ locals {
       write_access_table_arns = [
         module.transactions_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     edit_transaction = {
@@ -274,7 +286,8 @@ locals {
       write_access_table_arns = [
         module.transactions_table.table_arn,
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     delete_transaction = {
@@ -292,6 +305,7 @@ locals {
       delete_access_table_arns = [
         module.transactions_table.table_arn
       ]
+      send_message_access_queue_arns = []
     }
 
     create_link_token = {
@@ -309,7 +323,8 @@ locals {
         module.sessions_table.table_arn,
         module.users_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
 
     exchange_public_token = {
@@ -331,6 +346,9 @@ locals {
         module.sessions_table.table_arn,
         module.users_table.table_arn
       ]
+      send_message_access_queue_arns = [
+        module.queues["sync_transactions"].queue_arn
+      ]
     }
 
     sync_transactions = {
@@ -350,7 +368,8 @@ locals {
         module.users_table.table_arn,
         module.transactions_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns       = []
+      send_message_access_queue_arns = []
     }
   }
 }
@@ -486,17 +505,18 @@ resource "aws_iam_policy" "api_kms_access_policy" {
 }
 
 module "api_roles" {
-  source                     = "./modules/api_iam_roles"
-  for_each                   = local.API_ROLES
-  domain                     = var.domain
-  name                       = each.value.name
-  description                = each.value.description
-  secret_names               = each.value.secrets
-  read_table_access_arns     = each.value.read_access_table_arns
-  write_table_access_arns    = each.value.write_access_table_arns
-  delete_table_access_arns   = each.value.delete_access_table_arns
-  api_base_role              = module.api_base_role.arn
-  assume_api_role_principals = var.api_assume_role_additional_principals
+  source                         = "./modules/api_iam_roles"
+  for_each                       = local.API_ROLES
+  domain                         = var.domain
+  name                           = each.value.name
+  description                    = each.value.description
+  secret_names                   = each.value.secrets
+  read_table_access_arns         = each.value.read_access_table_arns
+  write_table_access_arns        = each.value.write_access_table_arns
+  delete_table_access_arns       = each.value.delete_access_table_arns
+  send_message_access_queue_arns = each.value.send_message_access_queue_arns
+  api_base_role                  = module.api_base_role.arn
+  assume_api_role_principals     = var.api_assume_role_additional_principals
 }
 
 

--- a/infra/infrastructure/canaries.tf
+++ b/infra/infrastructure/canaries.tf
@@ -20,10 +20,15 @@ module "canary_role" {
 module "canary_role_db_access" {
   source      = "./modules/iam_dynamodb_access_policy"
   policy_name = "canary-db-access-policy"
-  table_names = [
-    module.users_table.table_name,
-    module.sessions_table.table_name
+  read_access_table_arns = [
+    module.users_table.table_arn,
+    module.sessions_table.table_arn
   ]
+  write_access_table_arns = [
+    module.users_table.table_arn,
+    module.sessions_table.table_arn
+  ]
+  delete_access_table_arns = []
 }
 
 # canary requires access to auth secrets to create authenticated sessions

--- a/infra/infrastructure/modules/api_iam_roles/main.tf
+++ b/infra/infrastructure/modules/api_iam_roles/main.tf
@@ -41,16 +41,18 @@ module "api_iam_role_secrets_access" {
 }
 
 resource "aws_iam_role_policy_attachment" "db_access_attachment" {
-  count      = length(var.table_names) > 0 ? 1 : 0
+  count      = length(concat(var.read_table_access_arns, var.write_table_access_arns, var.delete_table_access_arns)) > 0 ? 1 : 0
   role       = aws_iam_role.api_iam_role.name
   policy_arn = module.api_iam_role_db_access[0].policy_arn
 }
 
 module "api_iam_role_db_access" {
-  count       = length(var.table_names) > 0 ? 1 : 0
-  source      = "../iam_dynamodb_access_policy"
-  policy_name = local.API_ROLE_DB_ACCESS_POLICY_NAME
-  table_names = var.table_names
+  count                    = length(concat(var.read_table_access_arns, var.write_table_access_arns, var.delete_table_access_arns)) > 0 ? 1 : 0
+  source                   = "../iam_dynamodb_access_policy"
+  policy_name              = local.API_ROLE_DB_ACCESS_POLICY_NAME
+  read_access_table_arns   = var.read_table_access_arns
+  write_access_table_arns  = var.write_table_access_arns
+  delete_access_table_arns = var.delete_table_access_arns
 }
 
 

--- a/infra/infrastructure/modules/api_iam_roles/main.tf
+++ b/infra/infrastructure/modules/api_iam_roles/main.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "api_iam_role_trust_policy" {
 
 resource "aws_iam_role_policy_attachment" "lambda_execution_access_attachment" {
   role       = aws_iam_role.api_iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy_attachment" "secrets_access_attachment" {

--- a/infra/infrastructure/modules/api_iam_roles/main.tf
+++ b/infra/infrastructure/modules/api_iam_roles/main.tf
@@ -2,6 +2,7 @@ locals {
   API_ROLE_NAME                       = "WalterBackend-API-${var.name}-Role-${var.domain}"
   API_ROLE_SECRETS_ACCESS_POLICY_NAME = "WalterBackend-API-${var.name}-Secrets-Policy-${var.domain}"
   API_ROLE_DB_ACCESS_POLICY_NAME      = "WalterBackend-API-${var.name}-DB-Policy-${var.domain}"
+  API_ROLE_SQS_ACCESS_POLICY_NAME     = "WalterBackend-API-${var.name}-SQS-Policy-${var.domain}"
 }
 
 resource "aws_iam_role" "api_iam_role" {
@@ -53,6 +54,20 @@ module "api_iam_role_db_access" {
   read_access_table_arns   = var.read_table_access_arns
   write_access_table_arns  = var.write_table_access_arns
   delete_access_table_arns = var.delete_table_access_arns
+}
+
+resource "aws_iam_role_policy_attachment" "sqs_access_attachment" {
+  count      = length(var.send_message_access_queue_arns) > 0 ? 1 : 0
+  role       = aws_iam_role.api_iam_role.name
+  policy_arn = module.api_iam_role_sqs_access[0].policy_arn
+}
+
+module "api_iam_role_sqs_access" {
+  count       = length(var.send_message_access_queue_arns) > 0 ? 1 : 0
+  source      = "../iam_sqs_queue_access_policy"
+  name        = local.API_ROLE_SQS_ACCESS_POLICY_NAME
+  queue_arns  = var.send_message_access_queue_arns
+  access_type = "producer"
 }
 
 

--- a/infra/infrastructure/modules/api_iam_roles/variables.tf
+++ b/infra/infrastructure/modules/api_iam_roles/variables.tf
@@ -38,6 +38,11 @@ variable "delete_table_access_arns" {
   type        = list(string)
 }
 
+variable "send_message_access_queue_arns" {
+  description = "The ARN(s) of the SQS queues that the API requires permissions to send messages."
+  type        = list(string)
+}
+
 variable "api_base_role" {
   description = "The IAM role used by the WalterBackend API function to assume the more specific API roles after routing."
   type        = string

--- a/infra/infrastructure/modules/api_iam_roles/variables.tf
+++ b/infra/infrastructure/modules/api_iam_roles/variables.tf
@@ -23,8 +23,18 @@ variable "secret_names" {
   type        = list(string)
 }
 
-variable "table_names" {
-  description = "The names of the WalterDB table(s) the API requires access to for executions."
+variable "read_table_access_arns" {
+  description = "The ARN(s) of the WalterDB DynamoDB tables that the API requires read access to items."
+  type        = list(string)
+}
+
+variable "write_table_access_arns" {
+  description = "The ARN(s) of the WalterDB DynamoDB tables that the API requires write access to items."
+  type        = list(string)
+}
+
+variable "delete_table_access_arns" {
+  description = "The ARNs of the WalterDB DynamoDB tables that the API requires delete access to items."
   type        = list(string)
 }
 

--- a/infra/infrastructure/modules/iam_dynamodb_access_policy/variables.tf
+++ b/infra/infrastructure/modules/iam_dynamodb_access_policy/variables.tf
@@ -1,9 +1,19 @@
-variable "table_names" {
-  description = "List of DynamoDB table names to grant access to."
-  type        = list(string)
-}
-
 variable "policy_name" {
   description = "Optional name for the IAM policy. If not provided, a default name will be used."
   type        = string
+}
+
+variable "read_access_table_arns" {
+  description = "List of DynamoDB table ARNs to grant READ access to. Index ARNs will be derived automatically."
+  type        = list(string)
+}
+
+variable "write_access_table_arns" {
+  description = "List of DynamoDB table ARNs to grant WRITE access to."
+  type        = list(string)
+}
+
+variable "delete_access_table_arns" {
+  description = "List of DynamoDB table ARNs to grant DELETE access to."
+  type        = list(string)
 }

--- a/infra/infrastructure/modules/iam_sqs_queue_access_policy/main.tf
+++ b/infra/infrastructure/modules/iam_sqs_queue_access_policy/main.tf
@@ -2,6 +2,13 @@ locals {
   is_consumer = lower(var.access_type) == "consumer"
 }
 
+resource "aws_iam_policy" "this" {
+  name        = var.name
+  description = var.description
+  policy      = data.aws_iam_policy_document.this.json
+  tags        = var.tags
+}
+
 data "aws_iam_policy_document" "this" {
   statement {
     sid    = local.is_consumer ? "SQSConsumePermissions" : "SQSProducePermissions"
@@ -20,11 +27,4 @@ data "aws_iam_policy_document" "this" {
 
     resources = var.queue_arns
   }
-}
-
-resource "aws_iam_policy" "this" {
-  name        = var.name
-  description = var.description
-  policy      = data.aws_iam_policy_document.this.json
-  tags        = var.tags
 }

--- a/infra/infrastructure/modules/iam_sqs_queue_access_policy/variables.tf
+++ b/infra/infrastructure/modules/iam_sqs_queue_access_policy/variables.tf
@@ -12,7 +12,6 @@ variable "description" {
 variable "access_type" {
   description = "Type of access this policy grants to the queues. One of: \"consumer\" or \"producer\"."
   type        = string
-  default     = "consumer"
 
   validation {
     condition     = contains(["consumer", "producer"], var.access_type)

--- a/infra/infrastructure/modules/workflow_iam_role/main.tf
+++ b/infra/infrastructure/modules/workflow_iam_role/main.tf
@@ -41,14 +41,16 @@ module "workflow_role_secrets_access" {
 }
 
 resource "aws_iam_role_policy_attachment" "db_access_attachment" {
-  count      = length(var.tables_access) > 0 ? 1 : 0
+  count      = length(concat(var.read_table_access_arns, var.write_table_access_arns, var.delete_table_access_arns)) > 0 ? 1 : 0
   role       = aws_iam_role.workflow_role.name
   policy_arn = module.workflow_role_db_access[0].policy_arn
 }
 
 module "workflow_role_db_access" {
-  count       = length(var.tables_access) > 0 ? 1 : 0
-  source      = "../iam_dynamodb_access_policy"
-  policy_name = local.WORKFLOW_DB_ACCESS_POLICY_NAME
-  table_names = var.tables_access
+  count                    = length(concat(var.read_table_access_arns, var.write_table_access_arns, var.delete_table_access_arns)) > 0 ? 1 : 0
+  source                   = "../iam_dynamodb_access_policy"
+  policy_name              = local.WORKFLOW_DB_ACCESS_POLICY_NAME
+  read_access_table_arns   = var.read_table_access_arns
+  write_access_table_arns  = var.write_table_access_arns
+  delete_access_table_arns = var.delete_table_access_arns
 }

--- a/infra/infrastructure/modules/workflow_iam_role/main.tf
+++ b/infra/infrastructure/modules/workflow_iam_role/main.tf
@@ -2,6 +2,7 @@ locals {
   WORKFLOW_ROLE_NAME                  = "WalterBackend-Workflow-${var.name}-Role-${var.domain}"
   WORKFLOW_SECRETS_ACCESS_POLICY_NAME = "WalterBackend-Workflow-${var.name}-Secrets-Policy-${var.domain}"
   WORKFLOW_DB_ACCESS_POLICY_NAME      = "WalterBackend-Workflow-${var.name}-DB-Policy-${var.domain}"
+  WORKFLOW_SQS_ACCESS_POLICY_NAME     = "WalterBackend-Workflow-${var.domain}-SQS-Policy-${var.domain}"
 }
 
 resource "aws_iam_role" "workflow_role" {
@@ -53,4 +54,18 @@ module "workflow_role_db_access" {
   read_access_table_arns   = var.read_table_access_arns
   write_access_table_arns  = var.write_table_access_arns
   delete_access_table_arns = var.delete_table_access_arns
+}
+
+resource "aws_iam_role_policy_attachment" "sqs_access_attachment" {
+  count      = length(var.receive_message_access_queue_arns) > 0 ? 1 : 0
+  role       = aws_iam_role.workflow_role.name
+  policy_arn = module.workflow_role_sqs_access[0].policy_arn
+}
+
+module "workflow_role_sqs_access" {
+  count       = length(var.receive_message_access_queue_arns) > 0 ? 1 : 0
+  source      = "../iam_sqs_queue_access_policy"
+  name        = local.WORKFLOW_SQS_ACCESS_POLICY_NAME
+  queue_arns  = var.receive_message_access_queue_arns
+  access_type = "consumer"
 }

--- a/infra/infrastructure/modules/workflow_iam_role/main.tf
+++ b/infra/infrastructure/modules/workflow_iam_role/main.tf
@@ -2,7 +2,7 @@ locals {
   WORKFLOW_ROLE_NAME                  = "WalterBackend-Workflow-${var.name}-Role-${var.domain}"
   WORKFLOW_SECRETS_ACCESS_POLICY_NAME = "WalterBackend-Workflow-${var.name}-Secrets-Policy-${var.domain}"
   WORKFLOW_DB_ACCESS_POLICY_NAME      = "WalterBackend-Workflow-${var.name}-DB-Policy-${var.domain}"
-  WORKFLOW_SQS_ACCESS_POLICY_NAME     = "WalterBackend-Workflow-${var.domain}-SQS-Policy-${var.domain}"
+  WORKFLOW_SQS_ACCESS_POLICY_NAME     = "WalterBackend-Workflow-${var.name}-SQS-Policy-${var.domain}"
 }
 
 resource "aws_iam_role" "workflow_role" {
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "workflow_role_trust_policy" {
 
 resource "aws_iam_role_policy_attachment" "lambda_execution_access_attachment" {
   role       = aws_iam_role.workflow_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy_attachment" "secrets_access_attachment" {

--- a/infra/infrastructure/modules/workflow_iam_role/variables.tf
+++ b/infra/infrastructure/modules/workflow_iam_role/variables.tf
@@ -38,6 +38,11 @@ variable "delete_table_access_arns" {
   type        = list(string)
 }
 
+variable "receive_message_access_queue_arns" {
+  description = "The ARN(s) of the SQS queues that the workflow can receive messages from for task processing."
+  type        = list(string)
+}
+
 variable "workflow_base_role" {
   description = "The IAM role used by the WalterBackend workflow function to assume the more specific workflow roles after routing."
   type        = string

--- a/infra/infrastructure/modules/workflow_iam_role/variables.tf
+++ b/infra/infrastructure/modules/workflow_iam_role/variables.tf
@@ -23,8 +23,18 @@ variable "secrets_access" {
   type        = list(string)
 }
 
-variable "tables_access" {
-  description = "The names of the WalterDB table(s) the workflow requires access to for executions."
+variable "read_table_access_arns" {
+  description = "The ARN(s) of the WalterDB DynamoDB tables that the workflow requires read access to items."
+  type        = list(string)
+}
+
+variable "write_table_access_arns" {
+  description = "The ARN(s) of the WalterDB DynamoDB tables that the workflow requires write access to items."
+  type        = list(string)
+}
+
+variable "delete_table_access_arns" {
+  description = "The ARNs of the WalterDB DynamoDB tables that the workflow requires delete access to items."
   type        = list(string)
 }
 

--- a/infra/infrastructure/workflows.tf
+++ b/infra/infrastructure/workflows.tf
@@ -6,9 +6,13 @@ locals {
       secrets = [
         module.secrets["Polygon"].secret_name
       ]
-      tables = [
-        module.securities_table.table_name
+      read_access_table_arns = [
+        module.securities_table.table_arn
       ]
+      write_access_table_arns = [
+        module.securities_table.table_arn
+      ]
+      delete_access_table_arns = []
       principals = [
         var.workflow_assume_role_additional_principals
       ]
@@ -20,11 +24,17 @@ locals {
       secrets = [
         module.secrets["Plaid"].secret_name
       ]
-      tables = [
-        module.users_table.table_name,
-        module.accounts_table.table_name,
-        module.transactions_table.table_name
+      read_access_table_arns = [
+        module.users_table.table_arn,
+        module.accounts_table.table_arn,
+        module.transactions_table.table_arn
       ]
+      write_access_table_arns = [
+        module.users_table.table_arn,
+        module.accounts_table.table_arn,
+        module.transactions_table.table_arn
+      ]
+      delete_access_table_arns = []
       principals = [
         var.workflow_assume_role_additional_principals
       ]
@@ -87,14 +97,16 @@ resource "aws_iam_policy" "workflow_kms_access_policy" {
 }
 
 module "workflow_roles" {
-  for_each              = local.WORKFLOW_ROLES
-  source                = "./modules/workflow_iam_role"
-  name                  = each.value.name
-  domain                = var.domain
-  description           = each.value.description
-  secrets_access        = each.value.secrets
-  tables_access         = each.value.tables
-  workflow_base_role    = module.workflow_base_role.arn
-  additional_principals = var.workflow_assume_role_additional_principals
+  for_each                 = local.WORKFLOW_ROLES
+  source                   = "./modules/workflow_iam_role"
+  name                     = each.value.name
+  domain                   = var.domain
+  description              = each.value.description
+  secrets_access           = each.value.secrets
+  read_table_access_arns   = each.value.read_access_table_arns
+  write_table_access_arns  = each.value.write_access_table_arns
+  delete_table_access_arns = each.value.delete_access_table_arns
+  workflow_base_role       = module.workflow_base_role.arn
+  additional_principals    = var.workflow_assume_role_additional_principals
 }
 

--- a/infra/infrastructure/workflows.tf
+++ b/infra/infrastructure/workflows.tf
@@ -12,7 +12,8 @@ locals {
       write_access_table_arns = [
         module.securities_table.table_arn
       ]
-      delete_access_table_arns = []
+      delete_access_table_arns   = []
+      receive_message_queue_arns = []
       principals = [
         var.workflow_assume_role_additional_principals
       ]
@@ -35,6 +36,9 @@ locals {
         module.transactions_table.table_arn
       ]
       delete_access_table_arns = []
+      receive_message_queue_arns = [
+        module.queues["sync_transactions"].queue_arn
+      ]
       principals = [
         var.workflow_assume_role_additional_principals
       ]
@@ -97,16 +101,17 @@ resource "aws_iam_policy" "workflow_kms_access_policy" {
 }
 
 module "workflow_roles" {
-  for_each                 = local.WORKFLOW_ROLES
-  source                   = "./modules/workflow_iam_role"
-  name                     = each.value.name
-  domain                   = var.domain
-  description              = each.value.description
-  secrets_access           = each.value.secrets
-  read_table_access_arns   = each.value.read_access_table_arns
-  write_table_access_arns  = each.value.write_access_table_arns
-  delete_table_access_arns = each.value.delete_access_table_arns
-  workflow_base_role       = module.workflow_base_role.arn
-  additional_principals    = var.workflow_assume_role_additional_principals
+  for_each                          = local.WORKFLOW_ROLES
+  source                            = "./modules/workflow_iam_role"
+  name                              = each.value.name
+  domain                            = var.domain
+  description                       = each.value.description
+  secrets_access                    = each.value.secrets
+  read_table_access_arns            = each.value.read_access_table_arns
+  write_table_access_arns           = each.value.write_access_table_arns
+  delete_table_access_arns          = each.value.delete_access_table_arns
+  receive_message_access_queue_arns = each.value.receive_message_queue_arns
+  workflow_base_role                = module.workflow_base_role.arn
+  additional_principals             = var.workflow_assume_role_additional_principals
 }
 

--- a/src/canaries/common/models.py
+++ b/src/canaries/common/models.py
@@ -11,6 +11,7 @@ class CanaryResponse:
     """
 
     api_name: str
+    request_id: str
     status: Status
     response_time_millis: float
 
@@ -20,6 +21,7 @@ class CanaryResponse:
             "body": json.dumps(
                 {
                     "Canary": self.api_name,
+                    "RequestId": self.request_id,
                     "Status": self.status.value,
                     "ResponseTimeMillis": self.response_time_millis,
                 }


### PR DESCRIPTION
## Summary

This PR separates the DynamoDB IAM actions granted to roles by read, write, and delete permissions.

This ensures that IAM roles that require access to WalterDB and its DynamoDB tables are granted access on a least-privileged basis. The roles can be granted permissions to read, write, and or delete items from a set of DynamoDB tables.

This is an improvement as previously the permissions were granted as a set of read, write, and delete but this change allows for more granular database access controls.

## Context

This change ensures access to WalterDB is least-privileged

## Changes

- [X] DynamoDB permissions are granted by read, write, and delete permissions
- [X] All Lambda IAM roles use the VPC basic execution role managed policy for ENI creation
- [X] The APIs and workflows that require queue access have producer/consumer permissions granted

## Testing

E2E testing in development.

## Notes

N/A
