### PR TITLE
feat: handle syncing updated and deleted transactions from plaid

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -100,21 +100,36 @@ def print_build_step_header(step_name: str, environment: str) -> None:
 def log_build_vars() -> None:
     print_build_step_header("BUILD VARS", APP_ENVIRONMENT)
 
-    print("Building new WalterBackend version with the following build variables:\n")
+    print("Building new WalterBackend version with the following build variables...\n")
 
-    build_info = {
-        "WalterBackend version": VERSION,
-        "WalterBackend image URI": WALTER_BACKEND_IMAGE_URI,
-        "Lambda functions": json.dumps(LAMBDA_FUNCTIONS, indent=4),
-        "Function alias": FUNCTION_ALIAS,
-        "Release description": RELEASE_DESCRIPTION,
-        "AWS region": AWS_REGION,
-        "AWS account ID": AWS_ACCOUNT_ID,
-        "Application environment": APP_ENVIRONMENT,
+    print("\nAWS Account and Environment Information:\n")
+    aws_account_info = {
+        "AWS Region": AWS_REGION,
+        "AWS Account ID": AWS_ACCOUNT_ID,
+        "Application Environment": APP_ENVIRONMENT,
     }
 
-    for key, value in build_info.items():
-        print(f"{key}: {value}")
+    for k, v in aws_account_info.items():
+        print(f"{k}: {v}")
+
+    print("\nWalterBackend Image Information:\n")
+    image_info = {
+        "WalterBackend Version": VERSION,
+        "WalterBackend Image URI": WALTER_BACKEND_IMAGE_URI,
+        "WalterBackend Release Description": RELEASE_DESCRIPTION,
+    }
+
+    for k, v in image_info.items():
+        print(f"{k}: {v}")
+
+    print("\nWalterBackend Serverless Functions Information:\n")
+    functions_info = {
+        "WalterBackend Serverless Functions": json.dumps(LAMBDA_FUNCTIONS, indent=4),
+        "WalterBackend API Function Alias": FUNCTION_ALIAS,
+    }
+
+    for k, v in functions_info.items():
+        print(f"{k}: {v}")
 
 
 def log_build_identity(sts_client: STSClient) -> None:

--- a/deploy.py
+++ b/deploy.py
@@ -100,12 +100,12 @@ def print_build_step_header(step_name: str, environment: str) -> None:
 def log_build_vars() -> None:
     print_build_step_header("BUILD VARS", APP_ENVIRONMENT)
 
-    print("Building new WalterBackend version with the following build variables:")
+    print("Building new WalterBackend version with the following build variables:\n")
 
     build_info = {
         "WalterBackend version": VERSION,
         "WalterBackend image URI": WALTER_BACKEND_IMAGE_URI,
-        "Lambda functions": ", ".join(LAMBDA_FUNCTIONS),
+        "Lambda functions": json.dumps(LAMBDA_FUNCTIONS, indent=4),
         "Function alias": FUNCTION_ALIAS,
         "Release description": RELEASE_DESCRIPTION,
         "AWS region": AWS_REGION,

--- a/infra/infrastructure/db.tf
+++ b/infra/infrastructure/db.tf
@@ -6,11 +6,12 @@ locals {
   SECURITIES_TABLE   = "Securities-${var.domain}"
   HOLDINGS_TABLE     = "Holdings-${var.domain}"
 
-  USERS_EMAIL_INDEX               = "Users-EmailIndex-${var.domain}"
-  ACCOUNTS_PLAID_ACCOUNT_ID_INDEX = "Accounts-PlaidAccountIdIndex-${var.domain}"
-  ACCOUNTS_PLAID_ITEM_ID_INDEX    = "Accounts-PlaidItemIdIndex-${var.domain}"
-  TRANSACTIONS_USER_INDEX         = "Transactions-UserIndex-${var.domain}"
-  SECURITIES_TICKER_INDEX         = "Securities-TickerIndex-${var.domain}"
+  USERS_EMAIL_INDEX                       = "Users-EmailIndex-${var.domain}"
+  ACCOUNTS_PLAID_ACCOUNT_ID_INDEX         = "Accounts-PlaidAccountIdIndex-${var.domain}"
+  ACCOUNTS_PLAID_ITEM_ID_INDEX            = "Accounts-PlaidItemIdIndex-${var.domain}"
+  TRANSACTIONS_USER_INDEX                 = "Transactions-UserIndex-${var.domain}"
+  TRANSACTIONS_PLAID_TRANSACTION_ID_INDEX = "Transactions-PlaidTransactionId-${var.domain}"
+  SECURITIES_TICKER_INDEX                 = "Securities-TickerIndex-${var.domain}"
 }
 
 /*******************

--- a/src/api/accounts/get_accounts/models.py
+++ b/src/api/accounts/get_accounts/models.py
@@ -10,6 +10,7 @@ from src.database.users.models import User
 
 @dataclass
 class GetAccountsResponseAccountDict:
+    linked_with_plaid: bool
     account_id: str
     institution_name: str
     account_name: str
@@ -20,6 +21,7 @@ class GetAccountsResponseAccountDict:
 
     def to_dict(self) -> dict:
         return {
+            "linked_with_plaid": self.linked_with_plaid,
             "account_id": self.account_id,
             "institution_name": self.institution_name,
             "account_name": self.account_name,
@@ -60,6 +62,7 @@ class GetAccountsResponseHoldingDict:
 
 @dataclass
 class GetAccountsResponseInvestmentAccountDict:
+    linked_with_plaid: bool
     account_id: str
     institution_name: str
     account_name: str
@@ -71,6 +74,7 @@ class GetAccountsResponseInvestmentAccountDict:
 
     def to_dict(self) -> dict:
         return {
+            "linked_with_plaid": self.linked_with_plaid,
             "account_id": self.account_id,
             "institution_name": self.institution_name,
             "account_name": self.account_name,
@@ -121,6 +125,7 @@ class GetAccountsResponseData:
                 holdings = self._get_holdings(account)
                 accounts.append(
                     GetAccountsResponseInvestmentAccountDict(
+                        linked_with_plaid=account.is_linked_with_plaid(),
                         account_id=account.account_id,
                         institution_name=account.institution_name,
                         account_name=account.account_name,
@@ -134,6 +139,7 @@ class GetAccountsResponseData:
             else:
                 accounts.append(
                     GetAccountsResponseAccountDict(
+                        linked_with_plaid=account.is_linked_with_plaid(),
                         account_id=account.account_id,
                         institution_name=account.institution_name,
                         account_name=account.account_name,

--- a/src/api/transactions/get_transactions/method.py
+++ b/src/api/transactions/get_transactions/method.py
@@ -212,6 +212,7 @@ class GetTransactions(WalterAPIMethod):
                                 "price_per_share": transaction.price_per_share,
                                 "quantity": transaction.quantity,
                                 "transaction_amount": transaction.transaction_amount,
+                                "is_plaid_transaction": transaction.is_plaid_transaction(),
                             }
                         )
                 case TransactionType.BANKING:
@@ -232,6 +233,7 @@ class GetTransactions(WalterAPIMethod):
                                 )[0],
                                 "merchant_name": transaction.merchant_name,
                                 "transaction_amount": transaction.transaction_amount,
+                                "is_plaid_transaction": transaction.is_plaid_transaction(),
                             }
                         )
 

--- a/src/database/accounts/models.py
+++ b/src/database/accounts/models.py
@@ -161,6 +161,13 @@ class Account(ABC):
 
         return ddb_item
 
+    def is_linked_with_plaid(self) -> bool:
+        # plaid cursor and last sync are nullable plaid vars so not great for
+        # determining if the account is linked with plaid
+        if self.plaid_item_id and self.plaid_access_token and self.account_id:
+            return True
+        return False
+
     @abstractmethod
     def to_dict(self) -> dict:
         pass

--- a/src/database/transactions/models.py
+++ b/src/database/transactions/models.py
@@ -173,6 +173,9 @@ class Transaction(ABC):
             return self.transaction_subtype in [BankingTransactionSubType.DEBIT]
         return False
 
+    def is_plaid_transaction(self) -> bool:
+        return self.plaid_transaction_id is not None
+
     @abstractmethod
     def to_dict(self) -> dict:
         pass

--- a/src/database/transactions/models.py
+++ b/src/database/transactions/models.py
@@ -120,6 +120,10 @@ class Transaction(ABC):
     def get_transaction_date(self) -> datetime:
         return datetime.strptime(self.transaction_date.split("#")[0], "%Y-%m-%d")
 
+    def update_transaction_date(self, new_date: datetime) -> str:
+        self.transaction_date = f"{new_date.strftime('%Y-%m-%d')}#{self.transaction_id}"
+        return self.transaction_date
+
     def _get_common_attributes_dict(self) -> dict:
         attributes = {
             "transaction_id": self.transaction_id,

--- a/src/plaid/client.py
+++ b/src/plaid/client.py
@@ -218,7 +218,6 @@ class PlaidClient:
             RuntimeError: If the secrets manager fails to provide the required
                 Plaid credentials.
         """
-        # TODO: Get Plaid credentials from secrets manager by environment (e.g. sandbox, production)
         if self.client_id is None or self.secret is None:
             self.client_id = self.walter_sm.get_plaid_client_id()
             self.secret = self.walter_sm.get_plaid_secret_key()

--- a/src/plaid/client.py
+++ b/src/plaid/client.py
@@ -21,7 +21,10 @@ from src.plaid.models import (
     ExchangePublicTokenResponse,
     SyncTransactionsResponse,
 )
-from src.plaid.transaction_converter import TransactionConverter
+from src.plaid.transaction_converter import (
+    TransactionConversionType,
+    TransactionConverter,
+)
 from src.utils.log import Logger
 
 LOG = Logger(__name__).get_logger()
@@ -164,19 +167,25 @@ class PlaidClient:
             LOG.info("Getting newly added transactions...")
             added_transactions = []
             for plaid_transaction in response["added"]:
-                transaction = self.transaction_converter.convert(plaid_transaction)
+                transaction = self.transaction_converter.convert(
+                    plaid_transaction, TransactionConversionType.NEW
+                )
                 added_transactions.append(transaction)
 
             LOG.info("Getting modified transactions...")
             modified_transactions = []
             for plaid_transaction in response["modified"]:
-                transaction = self.transaction_converter.convert(plaid_transaction)
+                transaction = self.transaction_converter.convert(
+                    plaid_transaction, TransactionConversionType.UPDATED
+                )
                 modified_transactions.append(transaction)
 
             LOG.info("Getting removed transactions...")
             removed_transactions = []
             for plaid_transaction in response["removed"]:
-                transaction = self.transaction_converter.convert(plaid_transaction)
+                transaction = self.transaction_converter.convert(
+                    plaid_transaction, TransactionConversionType.DELETED
+                )
                 removed_transactions.append(transaction)
 
             added.extend(added_transactions)

--- a/src/plaid/transaction_converter.py
+++ b/src/plaid/transaction_converter.py
@@ -88,7 +88,7 @@ class TransactionConverter:
                 # update transaction fields
                 transaction.transaction_amount = plaid_transaction["amount"]
                 transaction.merchant_name = self._get_merchant_name(plaid_transaction)
-                transaction.transaction_date = plaid_transaction["date"]
+                transaction.update_transaction_date(plaid_transaction["date"])
 
                 return transaction
             case TransactionConversionType.DELETED:

--- a/src/plaid/transaction_converter.py
+++ b/src/plaid/transaction_converter.py
@@ -63,6 +63,7 @@ class TransactionConverter:
     def __post_init__(self) -> None:
         LOG.debug("Initializing Transaction Converter")
         self.plaid_account_cache = {}
+        self.plaid_transaction_cache = {}
 
     def convert(
         self, plaid_transaction: dict, conversion_type: TransactionConversionType

--- a/src/plaid/transaction_converter.py
+++ b/src/plaid/transaction_converter.py
@@ -87,9 +87,7 @@ class TransactionConverter:
 
                 # update transaction fields
                 transaction.transaction_amount = plaid_transaction["amount"]
-                transaction.merchant_name = plaid_transaction.get(
-                    "merchant_name", "UNKNOWN MERCHANT"
-                )
+                transaction.merchant_name = self._get_merchant_name(plaid_transaction)
                 transaction.transaction_date = plaid_transaction["date"]
 
                 return transaction
@@ -150,7 +148,7 @@ class TransactionConverter:
         amount = plaid_transaction["amount"]
 
         # plaid merchant name is nullable
-        merchant_name = plaid_transaction.get("merchant_name", "UNKNOWN MERCHANT")
+        merchant_name = self._get_merchant_name(plaid_transaction)
 
         transaction_category = self.transaction_categorizer.categorize(
             merchant_name, amount
@@ -189,3 +187,10 @@ class TransactionConverter:
             raise ValueError("Transaction must be associated with the same account")
 
         return transaction
+
+    def _get_merchant_name(self, plaid_transaction: dict) -> str:
+        # merchant name is nullable
+        merchant: str = plaid_transaction.get("merchant_name", "UNKNOWN MERCHANT")
+        if merchant is None:
+            merchant = "UNKNOWN MERCHANT"
+        return merchant

--- a/src/plaid/transaction_converter.py
+++ b/src/plaid/transaction_converter.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Dict
+from enum import Enum
+from typing import Dict, List
 
 from src.ai.mlp.expenses import ExpenseCategorizerMLP
 from src.database.accounts.models import Account
@@ -7,7 +8,6 @@ from src.database.client import WalterDB
 from src.database.transactions.models import (
     BankingTransactionSubType,
     BankTransaction,
-    InvestmentTransaction,
     Transaction,
     TransactionType,
 )
@@ -34,27 +34,41 @@ PERSONAL_FINANCE_CATEGORY_TO_TRANSACTION_TYPE: Dict[
 """(dict): Mapping of personal finance categories to transaction types"""
 
 
+class TransactionConversionType(Enum):
+    """Transaction Conversion Types"""
+
+    NEW = "new"
+    UPDATED = "updated"
+    DELETED = "deleted"
+
+
 @dataclass
 class TransactionConverter:
     """
     Transaction Converter
 
     This class is responsible for converting transactions from the Plaid API to
-    WalterDB format.
+    WalterDB format. WalterBackend receives Plaid transactions via the SyncTransactions
+    API and webhooks. These events contain new, updated, and deleted transactions. This
+    converter class handles the appropriate conversion logic for each transaction type
+    to ensure consistently with WalterDB and valid database logic.
     """
 
     db: WalterDB
     transaction_categorizer: ExpenseCategorizerMLP
 
     plaid_account_cache: Dict[str, Account] = None
+    plaid_transaction_cache: Dict[str, Transaction] = None
 
     def __post_init__(self) -> None:
         LOG.debug("Initializing Transaction Converter")
         self.plaid_account_cache = {}
 
-    def convert(self, plaid_transaction: dict) -> Transaction:
-        LOG.debug(
-            f"Converting Plaid transaction to WalterDB format:\n{plaid_transaction}"
+    def convert(
+        self, plaid_transaction: dict, conversion_type: TransactionConversionType
+    ) -> Transaction:
+        LOG.info(
+            f"Converting Plaid '{conversion_type.value}' transaction to WalterDB format:\n{plaid_transaction}"
         )
 
         # verify account exists before converting transaction, each transaction
@@ -62,18 +76,26 @@ class TransactionConverter:
         plaid_account_id: str = plaid_transaction["account_id"]
         account: Account = self._verify_account_exists(plaid_account_id)
 
-        # get transaction type based on plaid category
-        plaid_category: str = plaid_transaction["personal_finance_category"]["primary"]
-        transaction_type: TransactionType = self._get_transaction_type(plaid_category)
+        match conversion_type:
+            case TransactionConversionType.NEW:
+                return self._create_new_transaction(account, plaid_transaction)
+            case TransactionConversionType.UPDATED:
+                transaction: Transaction = self._get_existing_transaction(
+                    account, plaid_transaction
+                )
 
-        # handle transaction conversion by transaction type
-        match transaction_type:
-            case TransactionType.BANKING:
-                return self._create_banking_transaction(account, plaid_transaction)
-            case TransactionType.INVESTMENT:
-                return self._create_investment_transaction(account, plaid_transaction)
+                # update transaction fields
+                transaction.transaction_amount = plaid_transaction["amount"]
+                transaction.merchant_name = plaid_transaction.get(
+                    "merchant_name", "UNKNOWN MERCHANT"
+                )
+                transaction.transaction_date = plaid_transaction["date"]
+
+                return transaction
+            case TransactionConversionType.DELETED:
+                return self._get_existing_transaction(account, plaid_transaction)
             case _:
-                raise ValueError(f"Unknown transaction type: {transaction_type}")
+                raise ValueError(f"Unknown conversion type: {conversion_type}")
 
     def _verify_account_exists(self, plaid_account_id: str) -> Account:
         # if account exists in cache, return it and don't query database again
@@ -101,43 +123,33 @@ class TransactionConverter:
         # write plaid_account_id to account_id mapping to cache
         self.plaid_account_cache[plaid_account_id] = account
 
+        # get transactions for account only when first encountering the account from the transaction
+        self._cache_account_transactions(account)
+
         return account
 
-    def _get_transaction_type(
-        self,
-        plaid_category: str,
-    ) -> TransactionType:
-        LOG.debug(f"Getting transaction type for Plaid category '{plaid_category}'")
-
-        personal_finance_category = PersonalFinanceCategories.from_string(
-            plaid_category
-        )
-
-        # throw exception if category mapping not found
-        try:
-            transaction_type = PERSONAL_FINANCE_CATEGORY_TO_TRANSACTION_TYPE[
-                personal_finance_category
-            ]
-        except KeyError:
-            raise ValueError(
-                f"Invalid Plaid personal finance category '{plaid_category}'!"
-            )
-
+    def _cache_account_transactions(self, account: Account) -> List[Transaction]:
         LOG.debug(
-            f"Transaction type for Plaid category '{plaid_category}': {transaction_type}"
+            f"Getting transactions for account '{account.account_id}' to cache for Plaid transaction ID mappings"
         )
+        transactions: List[Transaction] = self.db.get_transactions_by_account(
+            account.account_id
+        )
+        # add plaid transaction id to transaction mapping to cache
+        for transaction in transactions:
+            self.plaid_transaction_cache[transaction.plaid_transaction_id] = transaction
+        LOG.debug(
+            f"Found {len(transactions)} transactions for account '{account.account_id}'"
+        )
+        return transactions
 
-        return transaction_type
-
-    def _create_banking_transaction(
+    def _create_new_transaction(
         self, account: Account, plaid_transaction: dict
-    ) -> BankTransaction:
+    ) -> Transaction:
         amount = plaid_transaction["amount"]
 
         # plaid merchant name is nullable
-        merchant_name = plaid_transaction["merchant_name"]
-        if merchant_name is None:
-            merchant_name = "UNKNOWN MERCHANT"
+        merchant_name = plaid_transaction.get("merchant_name", "UNKNOWN MERCHANT")
 
         transaction_category = self.transaction_categorizer.categorize(
             merchant_name, amount
@@ -160,8 +172,19 @@ class TransactionConverter:
             plaid_account_id=plaid_transaction["account_id"],
         )
 
-    def _create_investment_transaction(
+    def _get_existing_transaction(
         self, account: Account, plaid_transaction: dict
-    ) -> InvestmentTransaction:
-        # TODO: Implement investment transaction conversion
-        raise NotImplementedError("Need to implement investment transaction conversion")
+    ) -> Transaction:
+        plaid_transaction_id: str = plaid_transaction["transaction_id"]
+
+        if plaid_transaction_id not in self.plaid_transaction_cache:
+            raise ValueError(
+                "Transaction ID is required to update or delete a transaction"
+            )
+
+        transaction: Transaction = self.plaid_transaction_cache[plaid_transaction_id]
+
+        if transaction.account_id != account.account_id:
+            raise ValueError("Transaction must be associated with the same account")
+
+        return transaction

--- a/src/workflows/sync_user_transactions.py
+++ b/src/workflows/sync_user_transactions.py
@@ -79,7 +79,6 @@ class SyncUserTransactions(Workflow):
             self.db.add_transaction(transaction)
 
         for transaction in modified_transactions:
-            # before we can update transaction we have to corresponding db entry
             self.db.update_transaction(transaction)
 
         for transaction in removed_transactions:

--- a/src/workflows/sync_user_transactions.py
+++ b/src/workflows/sync_user_transactions.py
@@ -79,7 +79,8 @@ class SyncUserTransactions(Workflow):
             self.db.add_transaction(transaction)
 
         for transaction in modified_transactions:
-            self.db.edit_transaction(transaction)
+            # before we can update transaction we have to corresponding db entry
+            self.db.update_transaction(transaction)
 
         for transaction in removed_transactions:
             self.db.delete_transaction(

--- a/tst/plaid/test_transaction_converter.py
+++ b/tst/plaid/test_transaction_converter.py
@@ -5,7 +5,10 @@ import pytest
 from src.ai.mlp.expenses import ExpenseCategorizerMLP
 from src.database.client import WalterDB
 from src.database.transactions.models import BankTransaction
-from src.plaid.transaction_converter import TransactionConverter
+from src.plaid.transaction_converter import (
+    TransactionConversionType,
+    TransactionConverter,
+)
 from tst.plaid.utils import create_plaid_transaction
 
 
@@ -26,7 +29,9 @@ def test_transaction_converter(transaction_converter: TransactionConverter) -> N
     plaid_transaction = create_plaid_transaction(
         plaid_account_id, plaid_transaction_id, merchant_name, amount, date
     )
-    transaction = transaction_converter.convert(plaid_transaction)
+    transaction = transaction_converter.convert(
+        plaid_transaction, TransactionConversionType.NEW
+    )
 
     assert isinstance(transaction, BankTransaction)
     assert transaction.plaid_account_id == plaid_account_id


### PR DESCRIPTION
## Summary

This PR adds logic to handle syncing transactions that have been updated or deleted. 

Plaid can modify and delete user transactions as time goes on for various reasons. `WalterBackend` needs to ensure that it can handle persisting the results of the synced transactions to the database to ensure it can reflect the user's transaction history accurately.

This change essentially refactors the `TransactionConverter` to convert transactions based on conversion type: `ADD`, `UPDATED`, and `DELETED. Where each conversion type is handled separately. 

For `UPDATED` and `DELETED` conversion types, the existing transaction is first looked up in the database to ensure its existence before modifying in the updated case or returning for deletion in the latter case.

The `ADD` conversion type creates a new transaction to persist to the database.

## Context

This PR ensures user's transactions are accurately synced with Plaid's history

## Changes

- [X] `TransactionConverter` handles `ADD`, `UPDATED`, and `DELETED` conversion types with conditional database lookups to ensure Plaid transactions are persisted correctly


## Testing

E2E testing in development.

## Notes

N/A
