### PR TITLE
docs: update arch diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Walter combines automation and intelligence to help you spend smarter, save fast
 
 ### Architecture
 
-![walter-backend-architecture-diagram](https://github.com/user-attachments/assets/75a99b3b-a1d7-4399-b0af-ec7a4c9510f7)
+![walter-backend-arch-diagram](https://github.com/user-attachments/assets/0364878b-b416-4adb-a6a8-e6974a891e3e)
 
 
 ## API Documentation


### PR DESCRIPTION
## Summary

Update `WalterBackend` arch diagram to include CloudFront CDN and S3 bucket.

I am about to add a CDN to `WalterBackend` served by S3 and this simply updates the arch diagram in the `README.md` to ensure the diagram remains up to date.

## Context

Documentation should be kept up to date.

## Changes
- [X] Updated `README.md` with new architecture diagram

## Testing

Not really tested...

## Notes

N/A