### PR TITLE
feat: add cloudfront cdn with s3

### DIFF
--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -48,3 +48,6 @@ workflow_assume_role_additional_principals = ["arn:aws:iam::010526272437:user/Wa
 # SyncUserTransactions Workflow Settings
 sync_transactions_max_concurrency    = 2
 sync_transactions_max_retry_attempts = 1
+
+# WalterBackend CloudFront CDN Settings
+cdn_bucket_access_additional_principals = ["arn:aws:iam::010526272437:user/WalterAIDeveloper"]

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -12,7 +12,7 @@ domain            = "dev"
 walter_backend_version = "0.0.0"
 
 # The logging level, can set to debug for more verbose logs
-log_level = "INFO"
+log_level = "DEBUG"
 
 # The number of days to retain application logs before deletion
 log_retention_in_days = 7

--- a/infra/infrastructure/cdn.tf
+++ b/infra/infrastructure/cdn.tf
@@ -1,0 +1,50 @@
+locals {
+  CDN_BUCKET_NAME_PREFIX                = "walter-backend-media"
+  CDN_ORIGIN_ACCESS_CONTROL_NAME_PREFIX = "WalterBackend-CDN-OriginAccessControl"
+}
+
+/*********************
+ * WalterBackend CDN *
+ *********************/
+
+module "cdn" {
+  source                      = "./modules/cloudfront_cdn"
+  domain                      = var.domain
+  bucket_regional_domain_name = module.cdn_bucket.bucket_regional_domain_name
+  origin_access_control_id    = aws_cloudfront_origin_access_control.oac.id
+}
+
+module "cdn_bucket" {
+  source      = "./modules/s3_bucket"
+  domain      = var.domain
+  name_prefix = local.CDN_BUCKET_NAME_PREFIX
+  read_access_principals = [
+    {
+      prefix     = "*",
+      principals = concat([], var.cdn_bucket_access_additional_principals)
+    }
+  ]
+  write_access_principals = [
+    {
+      prefix     = "*",
+      principals = concat([], var.cdn_bucket_access_additional_principals)
+    }
+  ]
+  delete_access_principals = [
+    {
+      prefix     = "*",
+      principals = concat([], var.cdn_bucket_access_additional_principals)
+    }
+  ]
+  cloudfront_distribution_arns = [
+    module.cdn.distribution_arn
+  ]
+}
+
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "${local.CDN_ORIGIN_ACCESS_CONTROL_NAME_PREFIX}-${var.domain}"
+  description                       = "OAC for CloudFront to access private S3 content."
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+  origin_access_control_origin_type = "s3"
+}

--- a/infra/infrastructure/modules/cloudfront_cdn/main.tf
+++ b/infra/infrastructure/modules/cloudfront_cdn/main.tf
@@ -1,0 +1,43 @@
+locals {
+  MEDIA_ORIGIN_ID = "WalterBackend-Media-Bucket-${var.domain}"
+}
+
+resource "aws_cloudfront_distribution" "media_cdn" {
+  enabled         = true
+  is_ipv6_enabled = true
+
+  origin {
+    domain_name              = var.bucket_regional_domain_name
+    origin_id                = local.MEDIA_ORIGIN_ID
+    origin_access_control_id = var.origin_access_control_id
+  }
+
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.MEDIA_ORIGIN_ID
+
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  price_class = "PriceClass_100" # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_cloudfront/PriceClass.html
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+

--- a/infra/infrastructure/modules/cloudfront_cdn/outputs.tf
+++ b/infra/infrastructure/modules/cloudfront_cdn/outputs.tf
@@ -1,0 +1,3 @@
+output "distribution_arn" {
+  value = aws_cloudfront_distribution.media_cdn.arn
+}

--- a/infra/infrastructure/modules/cloudfront_cdn/variables.tf
+++ b/infra/infrastructure/modules/cloudfront_cdn/variables.tf
@@ -1,0 +1,19 @@
+variable "domain" {
+  description = "The domain of WalterBackend."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "stg", "prod"], var.domain)
+    error_message = "The domain must be 'dev', 'stg', or 'prod'."
+  }
+}
+
+variable "bucket_regional_domain_name" {
+  description = ""
+  type        = string
+}
+
+variable "origin_access_control_id" {
+  description = "The ID of the OAC for CloudFront to access the S3 content."
+  type        = string
+}

--- a/infra/infrastructure/modules/s3_bucket/main.tf
+++ b/infra/infrastructure/modules/s3_bucket/main.tf
@@ -1,0 +1,215 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = "${var.name_prefix}-${var.domain}"
+}
+
+resource "aws_s3_bucket_versioning" "bucket_versioning" {
+  bucket = aws_s3_bucket.bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
+  bucket = aws_s3_bucket.bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.bucket_ownership_controls]
+
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = data.aws_iam_policy_document.bucket_policy_document.json
+}
+
+data "aws_iam_policy_document" "bucket_policy_document" {
+  dynamic "statement" {
+    for_each = var.read_access_principals
+    content {
+      sid    = "ReadAccess${replace(replace(statement.value.prefix, "/", ""), "*", "Wildcard")}${statement.key}"
+      effect = "Allow"
+
+      principals {
+        type        = "AWS"
+        identifiers = statement.value.principals
+      }
+
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetObjectAcl",
+        "s3:GetObjectVersionAcl"
+      ]
+
+      resources = [
+        "${aws_s3_bucket.bucket.arn}/${statement.value.prefix}"
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.read_access_principals
+    content {
+      sid    = "ListAccess${replace(replace(statement.value.prefix, "/", ""), "*", "Wildcard")}${statement.key}"
+      effect = "Allow"
+
+      principals {
+        type        = "AWS"
+        identifiers = statement.value.principals
+      }
+
+      actions = [
+        "s3:ListBucket"
+      ]
+
+      resources = [
+        aws_s3_bucket.bucket.arn
+      ]
+
+      condition {
+        test     = "StringLike"
+        variable = "s3:prefix"
+        values   = ["${statement.value.prefix}"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.write_access_principals
+    content {
+      sid    = "WriteAccess${replace(replace(statement.value.prefix, "/", ""), "*", "Wildcard")}${statement.key}"
+      effect = "Allow"
+
+      principals {
+        type        = "AWS"
+        identifiers = statement.value.principals
+      }
+
+      actions = [
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetObjectAcl",
+        "s3:GetObjectVersionAcl"
+      ]
+
+      resources = [
+        "${aws_s3_bucket.bucket.arn}/${statement.value.prefix}"
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.write_access_principals
+    content {
+      sid    = "WriteListAccess${replace(replace(statement.value.prefix, "/", ""), "*", "Wildcard")}${statement.key}"
+      effect = "Allow"
+
+      principals {
+        type        = "AWS"
+        identifiers = statement.value.principals
+      }
+
+      actions = [
+        "s3:ListBucket"
+      ]
+
+      resources = [
+        aws_s3_bucket.bucket.arn
+      ]
+
+      condition {
+        test     = "StringLike"
+        variable = "s3:prefix"
+        values   = ["${statement.value.prefix}"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.delete_access_principals
+    content {
+      sid    = "DeleteAccess${replace(replace(statement.value.prefix, "/", ""), "*", "Wildcard")}${statement.key}"
+      effect = "Allow"
+
+      principals {
+        type        = "AWS"
+        identifiers = statement.value.principals
+      }
+
+      actions = [
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetObject",
+        "s3:GetObjectVersion"
+      ]
+
+      resources = [
+        "${aws_s3_bucket.bucket.arn}/${statement.value.prefix}"
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.delete_access_principals
+    content {
+      sid    = "DeleteListAccess${replace(replace(statement.value.prefix, "/", ""), "*", "Wildcard")}${statement.key}"
+      effect = "Allow"
+
+      principals {
+        type        = "AWS"
+        identifiers = statement.value.principals
+      }
+
+      actions = [
+        "s3:ListBucket"
+      ]
+
+      resources = [
+        aws_s3_bucket.bucket.arn
+      ]
+
+      condition {
+        test     = "StringLike"
+        variable = "s3:prefix"
+        values   = ["${statement.value.prefix}"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.cloudfront_distribution_arns != null ? var.cloudfront_distribution_arns : []
+    content {
+      sid    = "CloudFrontReadAccess${replace(statement.value, ":", "_")}"
+      effect = "Allow"
+
+      principals {
+        type        = "Service"
+        identifiers = ["cloudfront.amazonaws.com"]
+      }
+
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectVersion"
+      ]
+
+      resources = [
+        "${aws_s3_bucket.bucket.arn}/public/*"
+      ]
+
+      condition {
+        test     = "StringEquals"
+        variable = "AWS:SourceArn"
+        values   = [statement.value]
+      }
+    }
+  }
+}

--- a/infra/infrastructure/modules/s3_bucket/outputs.tf
+++ b/infra/infrastructure/modules/s3_bucket/outputs.tf
@@ -1,0 +1,3 @@
+output "bucket_regional_domain_name" {
+  value = aws_s3_bucket.bucket.bucket_regional_domain_name
+}

--- a/infra/infrastructure/modules/s3_bucket/variables.tf
+++ b/infra/infrastructure/modules/s3_bucket/variables.tf
@@ -1,0 +1,92 @@
+variable "domain" {
+  description = "The domain of WalterBackend."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "stg", "prod"], var.domain)
+    error_message = "The domain must be 'dev', 'stg', or 'prod'."
+  }
+}
+
+variable "name_prefix" {
+  description = "The name prefix of the S3 bucket."
+  type        = string
+}
+
+variable "read_access_principals" {
+  description = "The AWS principal(s) that can read objects in the bucket scoped by prefix."
+  type = list(object({
+    prefix     = string
+    principals = list(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for item in var.read_access_principals :
+      can(regex("^[a-zA-Z0-9!_.*'()-/]*$", item.prefix))
+    ])
+    error_message = "All prefix values must contain only valid S3 prefix characters."
+  }
+
+  validation {
+    condition     = alltrue([for item in var.read_access_principals : (length(item.principals) > 0)])
+    error_message = "Each principals list must contain at least one principal."
+  }
+}
+
+variable "write_access_principals" {
+  description = "The AWS principal(s) that can write and update objects in the bucket scoped by prefix."
+  type = list(object({
+    prefix     = string
+    principals = list(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for item in var.write_access_principals :
+      can(regex("^[a-zA-Z0-9!_.*'()-/]*$", item.prefix))
+    ])
+    error_message = "All prefix values must contain only valid S3 prefix characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for item in var.write_access_principals :
+      (length(item.principals) > 0)
+    ])
+    error_message = "Each principals list must contain at least one principal."
+  }
+}
+
+variable "delete_access_principals" {
+  description = "The AWS principal(s) that can delete objects in the bucket scoped by prefix."
+  type = list(object({
+    prefix     = string
+    principals = list(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for item in var.delete_access_principals :
+      can(regex("^[a-zA-Z0-9!_.*'()-/]*$", item.prefix))
+    ])
+    error_message = "All prefix values must contain only valid S3 prefix characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for item in var.delete_access_principals :
+      (length(item.principals) > 0)
+    ])
+    error_message = "Each principals list must contain at least one principal."
+  }
+}
+
+variable "cloudfront_distribution_arns" {
+  description = "The ARN(s) of the CloudFront distributions that have read-only access to the public items in the bucket."
+  type        = list(string)
+  default     = []
+}

--- a/infra/infrastructure/variables.tf
+++ b/infra/infrastructure/variables.tf
@@ -273,4 +273,8 @@ variable "stripe_secret_key" {
   type        = string
 }
 
+variable "cdn_bucket_access_additional_principals" {
+  description = "The list of additional AWS principal(s) allowed to access the CDN S3 bucket."
+  type        = list(string)
+}
 

--- a/src/api/accounts/update_account.py
+++ b/src/api/accounts/update_account.py
@@ -136,7 +136,7 @@ class UpdateAccount(WalterAPIMethod):
         account.account_name = body["account_name"]
         account.account_mask = body["account_mask"]
         account.balance = float(body["balance"])  # ensure float
-        account.logo_url = body["logo_url"]
+        account.logo_s3_uri = body["logo_url"]
         account.updated_at = datetime.now(timezone.utc)
 
         # Persist changes

--- a/src/api/transactions/get_transactions/method.py
+++ b/src/api/transactions/get_transactions/method.py
@@ -211,6 +211,7 @@ class GetTransactions(WalterAPIMethod):
                                 "transaction_category": transaction.transaction_category.value,
                                 "price_per_share": transaction.price_per_share,
                                 "quantity": transaction.quantity,
+                                "merchant_logo_url": self._get_merchant_logo_url(transaction.merchant_logo_s3_uri),
                                 "transaction_amount": transaction.transaction_amount,
                                 "is_plaid_transaction": transaction.is_plaid_transaction(),
                             }
@@ -232,9 +233,16 @@ class GetTransactions(WalterAPIMethod):
                                     "#"
                                 )[0],
                                 "merchant_name": transaction.merchant_name,
+                                "merchant_logo_url": self._get_merchant_logo_url(
+                                    transaction.merchant_logo_s3_uri
+                                ),
                                 "transaction_amount": transaction.transaction_amount,
                                 "is_plaid_transaction": transaction.is_plaid_transaction(),
                             }
                         )
 
         return account_transactions
+
+    def _get_merchant_logo_url(self, merchant_logo_s3_uri: str) -> str:
+        key = merchant_logo_s3_uri.split("public/")[-1]
+        return f"https://d2v0gz9k690ozv.cloudfront.net/public/{key}"

--- a/src/api/transactions/get_transactions/method.py
+++ b/src/api/transactions/get_transactions/method.py
@@ -211,7 +211,9 @@ class GetTransactions(WalterAPIMethod):
                                 "transaction_category": transaction.transaction_category.value,
                                 "price_per_share": transaction.price_per_share,
                                 "quantity": transaction.quantity,
-                                "merchant_logo_url": self._get_merchant_logo_url(transaction.merchant_logo_s3_uri),
+                                "merchant_logo_url": self._get_merchant_logo_url(
+                                    transaction.merchant_logo_s3_uri
+                                ),
                                 "transaction_amount": transaction.transaction_amount,
                                 "is_plaid_transaction": transaction.is_plaid_transaction(),
                             }

--- a/src/aws/s3/client.py
+++ b/src/aws/s3/client.py
@@ -79,6 +79,17 @@ class WalterS3Client:
             )
             raise error
 
+    def does_object_exist(self, bucket: str, key: str) -> bool:
+        uri = WalterS3Client.get_uri(bucket, key)
+        log.debug(f"Checking if object exists in S3 with URI '{uri}'")
+        try:
+            self.client.head_object(Bucket=bucket, Key=key)
+            log.debug(f"Object exists in S3 with URI '{uri}'")
+            return True
+        except ClientError:
+            log.debug(f"Object does not exist in S3 with URI '{uri}'")
+            return False
+
     def download_object(self, bucket: str, key: str) -> BytesIO:
         log.debug(
             f"Downloading object from S3 with URI '{WalterS3Client.get_uri(bucket, key)}'"

--- a/src/database/accounts/models.py
+++ b/src/database/accounts/models.py
@@ -303,7 +303,7 @@ class DepositoryAccount(Account):
         plaid_last_sync_at: Optional[datetime] = None,
         logo_s3_uri: Optional[
             str
-        ] = f"s3://walter-backend-media-{DOMAIN}/public/logos/default-depository-account.png",
+        ] = f"s3://walter-backend-media-{DOMAIN.value}/public/logos/default-depository-account-logo.png",
     ) -> None:
         super().__init__(
             account_id=account_id,
@@ -424,7 +424,7 @@ class CreditAccount(Account):
         plaid_last_sync_at: Optional[datetime] = None,
         logo_s3_uri: Optional[
             str
-        ] = f"s3://walter-backend-media-{DOMAIN}/public/logos/default-credit-account.png",
+        ] = f"s3://walter-backend-media-{DOMAIN.value}/public/logos/default-credit-account-logo.png",
     ) -> None:
         super().__init__(
             account_id=account_id,
@@ -544,7 +544,7 @@ class InvestmentAccount(Account):
         plaid_last_sync_at: Optional[datetime] = None,
         logo_s3_uri: Optional[
             str
-        ] = f"s3://walter-backend-media-{DOMAIN}/public/logos/default-depository-account.png",
+        ] = f"s3://walter-backend-media-{DOMAIN.value}/public/logos/default-investment-account-logo.png",
     ) -> None:
         super().__init__(
             account_id=account_id,
@@ -664,7 +664,7 @@ class LoanAccount(Account):
         plaid_last_sync_at: Optional[datetime] = None,
         logo_s3_uri: Optional[
             str
-        ] = f"s3://walter-backend-media-{DOMAIN}/public/logos/default-loan-account.png",
+        ] = f"s3://walter-backend-media-{DOMAIN.value}/public/logos/default-loan-account-logo.png",
     ) -> None:
         super().__init__(
             account_id=account_id,

--- a/src/database/accounts/models.py
+++ b/src/database/accounts/models.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
+from src.environment import DOMAIN
+
 
 class AccountType(Enum):
     """Account Types"""
@@ -24,8 +26,6 @@ class AccountType(Enum):
 class Account(ABC):
     """Account Model"""
 
-    DEFAULT_LOGO_URL = "https://walterai-public-media-dev.s3.us-east-1.amazonaws.com/cash-accounts/default/logo.svg"
-
     def __init__(
         self,
         account_id: str,
@@ -45,7 +45,7 @@ class Account(ABC):
         plaid_item_id: Optional[str] = None,
         plaid_cursor: Optional[str] = None,
         plaid_last_sync_at: Optional[datetime] = None,
-        logo_url: Optional[str] = DEFAULT_LOGO_URL,
+        logo_s3_uri: Optional[str] = None,
     ) -> None:
         self.account_id = account_id
         self.user_id = user_id
@@ -64,7 +64,7 @@ class Account(ABC):
         self.plaid_item_id = plaid_item_id
         self.plaid_cursor = plaid_cursor
         self.plaid_last_sync_at = plaid_last_sync_at
-        self.logo_url = logo_url
+        self.logo_s3_uri = logo_s3_uri
 
     def get_common_attributes_dict(self) -> dict:
         return {
@@ -87,7 +87,7 @@ class Account(ABC):
             "plaid_last_sync_at": (
                 self.plaid_last_sync_at.isoformat() if self.plaid_last_sync_at else None
             ),
-            "logo_url": self.logo_url,
+            "logo_s3_uri": self.logo_s3_uri,
         }
 
     def get_common_attributes_ddb_item(self) -> dict:
@@ -125,8 +125,8 @@ class Account(ABC):
             "updated_at": {
                 "S": self.updated_at.isoformat(),
             },
-            "logo_url": {
-                "S": self.logo_url,
+            "logo_s3_uri": {
+                "S": self.logo_s3_uri,
             },
         }
 
@@ -301,7 +301,9 @@ class DepositoryAccount(Account):
         plaid_item_id: Optional[str] = None,
         plaid_cursor: Optional[str] = None,
         plaid_last_sync_at: Optional[datetime] = None,
-        logo_url: Optional[str] = Account.DEFAULT_LOGO_URL,
+        logo_s3_uri: Optional[
+            str
+        ] = f"s3://walter-backend-media-{DOMAIN}/public/logos/default-depository-account.png",
     ) -> None:
         super().__init__(
             account_id=account_id,
@@ -321,7 +323,7 @@ class DepositoryAccount(Account):
             plaid_item_id=plaid_item_id,
             plaid_cursor=plaid_cursor,
             plaid_last_sync_at=plaid_last_sync_at,
-            logo_url=logo_url,
+            logo_s3_uri=logo_s3_uri,
         )
 
     def to_dict(self) -> dict:
@@ -391,7 +393,7 @@ class DepositoryAccount(Account):
             updated_at=datetime.fromisoformat(ddb_item["updated_at"]["S"]),
             plaid_institution_id=ddb_item.get("plaid_institution_id", {}).get("S"),
             plaid_account_id=ddb_item.get("plaid_account_id", {}).get("S"),
-            logo_url=ddb_item["logo_url"]["S"],
+            logo_s3_uri=ddb_item["logo_s3_uri"]["S"],
             plaid_access_token=ddb_item.get("plaid_access_token", {}).get("S"),
             plaid_cursor=ddb_item.get("plaid_cursor", {}).get("S"),
             plaid_item_id=ddb_item.get("plaid_item_id", {}).get("S"),
@@ -420,7 +422,9 @@ class CreditAccount(Account):
         plaid_item_id: Optional[str] = None,
         plaid_cursor: Optional[str] = None,
         plaid_last_sync_at: Optional[datetime] = None,
-        logo_url: Optional[str] = Account.DEFAULT_LOGO_URL,
+        logo_s3_uri: Optional[
+            str
+        ] = f"s3://walter-backend-media-{DOMAIN}/public/logos/default-credit-account.png",
     ) -> None:
         super().__init__(
             account_id=account_id,
@@ -440,7 +444,7 @@ class CreditAccount(Account):
             plaid_item_id=plaid_item_id,
             plaid_cursor=plaid_cursor,
             plaid_last_sync_at=plaid_last_sync_at,
-            logo_url=logo_url,
+            logo_s3_uri=logo_s3_uri,
         )
 
     def to_dict(self) -> dict:
@@ -509,7 +513,7 @@ class CreditAccount(Account):
             updated_at=datetime.fromisoformat(ddb_item["updated_at"]["S"]),
             plaid_institution_id=ddb_item.get("plaid_institution_id", {}).get("S"),
             plaid_account_id=ddb_item.get("plaid_account_id", {}).get("S"),
-            logo_url=ddb_item["logo_url"]["S"],
+            logo_s3_uri=ddb_item["logo_s3_uri"]["S"],
             plaid_access_token=ddb_item.get("plaid_access_token", {}).get("S"),
             plaid_item_id=ddb_item.get("plaid_item_id", {}).get("S"),
             plaid_cursor=ddb_item.get("plaid_cursor", {}).get("S"),
@@ -538,7 +542,9 @@ class InvestmentAccount(Account):
         plaid_item_id: Optional[str] = None,
         plaid_cursor: Optional[str] = None,
         plaid_last_sync_at: Optional[datetime] = None,
-        logo_url: Optional[str] = Account.DEFAULT_LOGO_URL,
+        logo_s3_uri: Optional[
+            str
+        ] = f"s3://walter-backend-media-{DOMAIN}/public/logos/default-depository-account.png",
     ) -> None:
         super().__init__(
             account_id=account_id,
@@ -558,7 +564,7 @@ class InvestmentAccount(Account):
             plaid_item_id=plaid_item_id,
             plaid_cursor=plaid_cursor,
             plaid_last_sync_at=plaid_last_sync_at,
-            logo_url=logo_url,
+            logo_s3_uri=logo_s3_uri,
         )
 
     def to_dict(self) -> dict:
@@ -625,7 +631,7 @@ class InvestmentAccount(Account):
             ),
             created_at=datetime.fromisoformat(ddb_item["created_at"]["S"]),
             updated_at=datetime.fromisoformat(ddb_item["updated_at"]["S"]),
-            logo_url=ddb_item["logo_url"]["S"],
+            logo_s3_uri=ddb_item["logo_s3_uri"]["S"],
             plaid_institution_id=ddb_item.get("plaid_institution_id", {}).get("S"),
             plaid_account_id=ddb_item.get("plaid_account_id", {}).get("S"),
             plaid_access_token=ddb_item.get("plaid_access_token", {}).get("S"),
@@ -656,7 +662,9 @@ class LoanAccount(Account):
         plaid_item_id: Optional[str] = None,
         plaid_cursor: Optional[str] = None,
         plaid_last_sync_at: Optional[datetime] = None,
-        logo_url: Optional[str] = Account.DEFAULT_LOGO_URL,
+        logo_s3_uri: Optional[
+            str
+        ] = f"s3://walter-backend-media-{DOMAIN}/public/logos/default-loan-account.png",
     ) -> None:
         super().__init__(
             account_id=account_id,
@@ -676,7 +684,7 @@ class LoanAccount(Account):
             plaid_item_id=plaid_item_id,
             plaid_cursor=plaid_cursor,
             plaid_last_sync_at=plaid_last_sync_at,
-            logo_url=logo_url,
+            logo_s3_uri=logo_s3_uri,
         )
 
     def to_dict(self) -> dict:
@@ -706,7 +714,7 @@ class LoanAccount(Account):
             ),
             created_at=datetime.fromisoformat(ddb_item["created_at"]["S"]),
             updated_at=datetime.fromisoformat(ddb_item["updated_at"]["S"]),
-            logo_url=ddb_item["logo_url"]["S"],
+            logo_s3_uri=ddb_item["logo_s3_uri"]["S"],
             plaid_institution_id=ddb_item.get("plaid_institution_id", {}).get("S"),
             plaid_account_id=ddb_item.get("plaid_account_id", {}).get("S"),
             plaid_access_token=ddb_item.get("plaid_access_token", {}).get("S"),

--- a/src/database/transactions/models.py
+++ b/src/database/transactions/models.py
@@ -93,7 +93,7 @@ class TransactionCategory(Enum):
 class Transaction(ABC):
     """Transaction Model"""
 
-    DEFAULT_TRANSACTION_LOGO_S3_URI = f"s3://walterai-public-media-{DOMAIN.value}/transaction_logos/default-merchant-logo.png"
+    DEFAULT_MERCHANT_LOGO_S3_URI = f"s3://walter-backend-media-{DOMAIN.value}/public/logos/default-merchant-logo.png"
 
     def __init__(
         self,
@@ -105,7 +105,7 @@ class Transaction(ABC):
         transaction_category: TransactionCategory,
         transaction_date: datetime,
         transaction_amount: float,
-        transaction_logo_s3_uri: Optional[str] = None,
+        merchant_logo_s3_uri: Optional[str] = None,
         plaid_transaction_id: Optional[str] = None,
         plaid_account_id: Optional[str] = None,
     ) -> None:
@@ -119,10 +119,10 @@ class Transaction(ABC):
             f"{transaction_date.strftime('%Y-%m-%d')}#{transaction_id}"
         )
         self.transaction_amount = transaction_amount
-        # ensure non-null transaction logo
-        if transaction_logo_s3_uri is None:
-            transaction_logo_s3_uri = self.DEFAULT_TRANSACTION_LOGO_S3_URI
-        self.transaction_logo_s3_uri = transaction_logo_s3_uri
+        # ensure non-null merchant logo
+        if merchant_logo_s3_uri is None:
+            merchant_logo_s3_uri = self.DEFAULT_MERCHANT_LOGO_S3_URI
+        self.merchant_logo_s3_uri = merchant_logo_s3_uri
         self.plaid_transaction_id = plaid_transaction_id
         self.plaid_account_id = plaid_account_id
 
@@ -143,7 +143,7 @@ class Transaction(ABC):
             "transaction_category": self.transaction_category.value,
             "transaction_date": self.transaction_date.split("#")[0],
             "transaction_amount": self.transaction_amount,
-            "transaction_logo_s3_uri": self.transaction_logo_s3_uri,
+            "merchant_logo_s3_uri": self.merchant_logo_s3_uri,
         }
 
         # add optional fields to return item
@@ -164,7 +164,7 @@ class Transaction(ABC):
             "transaction_category": {"S": self.transaction_category.value},
             "transaction_date": {"S": self.transaction_date},
             "transaction_amount": {"N": str(self.transaction_amount)},
-            "transaction_logo_s3_uri": {"S": self.transaction_logo_s3_uri},
+            "merchant_logo_s3_uri": {"S": self.merchant_logo_s3_uri},
         }
 
         # add optional fields to return item
@@ -222,7 +222,7 @@ class InvestmentTransaction(Transaction):
         security_id: str,
         quantity: float,
         price_per_share: float,
-        transaction_logo_s3_uri: Optional[str] = None,
+        merchant_logo_s3_uri: Optional[str] = None,
         plaid_transaction_id: Optional[str] = None,
         plaid_account_id: Optional[str] = None,
     ) -> None:
@@ -235,7 +235,7 @@ class InvestmentTransaction(Transaction):
             transaction_category,
             transaction_date,
             transaction_amount,
-            transaction_logo_s3_uri,
+            merchant_logo_s3_uri,
             plaid_transaction_id,
             plaid_account_id,
         )
@@ -293,7 +293,7 @@ class InvestmentTransaction(Transaction):
             security_id=f"sec-{exchange.lower()}-{ticker.lower()}",
             quantity=quantity,
             price_per_share=price_per_share,
-            transaction_logo_s3_uri=None,
+            merchant_logo_s3_uri=None,
             plaid_transaction_id=plaid_transaction_id,
             plaid_account_id=plaid_account_id,
         )
@@ -319,7 +319,7 @@ class InvestmentTransaction(Transaction):
             transaction_amount=float(ddb_item["transaction_amount"]["N"]),
             security_id=ddb_item["security_id"]["S"],
             quantity=float(ddb_item["quantity"]["N"]),
-            transaction_logo_s3_uri=ddb_item["transaction_logo_s3_uri"]["S"],
+            merchant_logo_s3_uri=ddb_item["merchant_logo_s3_uri"]["S"],
             price_per_share=float(ddb_item["price_per_share"]["N"]),
             plaid_transaction_id=ddb_item.get("plaid_transaction_id", {}).get("S"),
             plaid_account_id=ddb_item.get("plaid_account_id", {}).get("S"),
@@ -340,7 +340,7 @@ class BankTransaction(Transaction):
         transaction_date: datetime,
         transaction_amount: float,
         merchant_name: str,
-        transaction_logo_s3_uri: Optional[str] = None,
+        merchant_logo_s3_uri: Optional[str] = None,
         plaid_transaction_id: Optional[str] = None,
         plaid_account_id: Optional[str] = None,
     ) -> None:
@@ -353,7 +353,7 @@ class BankTransaction(Transaction):
             transaction_category,
             transaction_date,
             transaction_amount,
-            transaction_logo_s3_uri,
+            merchant_logo_s3_uri,
             plaid_transaction_id,
             plaid_account_id,
         )
@@ -382,7 +382,7 @@ class BankTransaction(Transaction):
         transaction_date: datetime,
         transaction_amount: float,
         merchant_name: str,
-        transaction_logo_s3_uri: Optional[str] = None,
+        merchant_logo_s3_uri: Optional[str] = None,
         plaid_transaction_id: Optional[str] = None,
         plaid_account_id: Optional[str] = None,
     ):
@@ -396,7 +396,7 @@ class BankTransaction(Transaction):
             transaction_date=transaction_date,
             transaction_amount=transaction_amount,
             merchant_name=merchant_name,
-            transaction_logo_s3_uri=transaction_logo_s3_uri,
+            merchant_logo_s3_uri=merchant_logo_s3_uri,
             plaid_transaction_id=plaid_transaction_id,
             plaid_account_id=plaid_account_id,
         )
@@ -421,7 +421,7 @@ class BankTransaction(Transaction):
             ),
             transaction_amount=float(ddb_item["transaction_amount"]["N"]),
             merchant_name=ddb_item["merchant_name"]["S"],
-            transaction_logo_s3_uri=ddb_item["transaction_logo_s3_uri"]["S"],
+            merchant_logo_s3_uri=ddb_item["merchant_logo_s3_uri"]["S"],
             plaid_transaction_id=ddb_item.get("plaid_transaction_id", {}).get("S"),
             plaid_account_id=ddb_item.get("plaid_account_id", {}).get("S"),
         )

--- a/src/plaid/transaction_converter.py
+++ b/src/plaid/transaction_converter.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+import requests
 
 from src.ai.mlp.expenses import ExpenseCategorizerMLP
 from src.database.accounts.models import Account
@@ -11,6 +13,7 @@ from src.database.transactions.models import (
     Transaction,
     TransactionType,
 )
+from src.media.bucket import MediaBucket
 from src.plaid.models import PersonalFinanceCategories
 from src.utils.log import Logger
 
@@ -42,7 +45,7 @@ class TransactionConversionType(Enum):
     DELETED = "deleted"
 
 
-@dataclass
+@dataclass(kw_only=True)
 class TransactionConverter:
     """
     Transaction Converter
@@ -56,6 +59,7 @@ class TransactionConverter:
 
     db: WalterDB
     transaction_categorizer: ExpenseCategorizerMLP
+    media_bucket: MediaBucket
 
     plaid_account_cache: Dict[str, Account] = None
     plaid_transaction_cache: Dict[str, Transaction] = None
@@ -79,6 +83,10 @@ class TransactionConverter:
 
         match conversion_type:
             case TransactionConversionType.NEW:
+                # For each new transaction, upload new merchant logos to media bucket
+                # so WalterBackend can serve the logos from CDN with low-latency
+                self._upload_merchant_logo_if_not_present(plaid_transaction)
+
                 return self._create_new_transaction(account, plaid_transaction)
             case TransactionConversionType.UPDATED:
                 transaction: Transaction = self._get_existing_transaction(
@@ -193,4 +201,51 @@ class TransactionConverter:
         merchant: str = plaid_transaction.get("merchant_name", "UNKNOWN MERCHANT")
         if merchant is None:
             merchant = "UNKNOWN MERCHANT"
-        return merchant
+
+        name: str = plaid_transaction.get("name", "UNKNOWN_NAME")
+        if name is None:
+            name = "UNKNOWN_NAME"
+
+        if merchant != "UNKNOWN MERCHANT":
+            return merchant
+
+        if name != "UNKNOWN_NAME":
+            return name
+
+        return "UNKNOWN"
+
+    def _upload_merchant_logo_if_not_present(self, plaid_transaction: dict) -> None:
+        LOG.debug(
+            "Attempting to upload new Plaid merchant logo to media bucket if not already present..."
+        )
+
+        # logos can be null, so just skip upload if not present and transaction will use default logo
+        logo_url: Optional[str] = plaid_transaction.get("logo_url", None)
+        if logo_url is None:
+            LOG.debug("Merchant logo URL is null, skipping upload")
+            return
+
+        LOG.debug(
+            f"Merchant logo URL is not null, checking media bucket for logo: '{logo_url}'"
+        )
+
+        logo_name = logo_url.split("/")[-1]
+        logo_key = f"logos/{logo_name}"
+        if self.media_bucket.does_public_file_exist(logo_key):
+            LOG.debug(
+                f"Logo '{logo_name}' already exists in media bucket, skipping upload"
+            )
+            return
+
+        LOG.debug(f"Logo '{logo_name}' does not exist in media bucket, uploading...")
+
+        resp = requests.get(logo_url)
+        resp.raise_for_status()
+        body = resp.content
+
+        self.media_bucket.upload_public_contents(
+            name=logo_key,
+            contents=body,
+        )
+
+        LOG.debug(f"Logo '{logo_name}' uploaded successfully!")

--- a/tst/api/accounts/test_update_account.py
+++ b/tst/api/accounts/test_update_account.py
@@ -67,7 +67,7 @@ def test_update_account_success(
     assert updated["account_name"] == "Taxable"
     assert updated["account_mask"] == "4321"
     assert updated["balance"] == 999.99
-    assert updated["logo_url"] == "https://logo.example.com"
+    assert updated["logo_s3_uri"] == "https://logo.example.com"
 
 
 def test_update_account_failure_invalid_account_type(

--- a/tst/aws/mock.py
+++ b/tst/aws/mock.py
@@ -5,6 +5,8 @@ from mypy_boto3_s3.client import S3Client
 from mypy_boto3_secretsmanager.client import SecretsManagerClient
 from mypy_boto3_sqs import SQSClient
 
+from src.environment import Domain
+from src.media.bucket import MediaBucket
 from tst.constants import (
     SECRETS_TEST_FILE,
     SYNC_TRANSACTIONS_TASK_QUEUE_NAME,
@@ -56,7 +58,10 @@ class MockS3:
     s3: S3Client
 
     def initialize(self) -> None:
-        pass
+        self._create_bucket(MediaBucket._get_bucket_name(Domain.TESTING))
+
+    def _create_bucket(self, bucket_name: str) -> None:
+        self.s3.create_bucket(Bucket=bucket_name)
 
 
 @dataclass

--- a/tst/conftest.py
+++ b/tst/conftest.py
@@ -21,6 +21,7 @@ from src.environment import Domain
 from src.factory import ClientFactory
 from src.investments.holdings.updater import HoldingUpdater
 from src.investments.securities.updater import SecurityUpdater
+from src.media.bucket import MediaBucket
 from src.metrics.client import DatadogMetricsClient
 from src.transactions.queue import SyncUserTransactionsTaskQueue
 from src.workflows.factory import WorkflowFactory
@@ -171,6 +172,16 @@ def sync_transactions_task_queue(
 
 
 @pytest.fixture
+def media_bucket(
+    walter_s3: WalterS3Client,
+) -> MediaBucket:
+    return MediaBucket(
+        client=walter_s3,
+        domain=Domain.TESTING,
+    )
+
+
+@pytest.fixture
 def transactions_categorizer() -> ExpenseCategorizerMLP:
     return MockTransactionsCategorizer()
 
@@ -207,6 +218,7 @@ def client_factory(
     transactions_categorizer: MockTransactionsCategorizer,
     plaid_client: MockPlaidClient,
     sync_transactions_task_queue: SyncUserTransactionsTaskQueue,
+    media_bucket: MediaBucket,
 ) -> ClientFactory:
     # create a client factory
     client_factory: ClientFactory = ClientFactory(
@@ -228,6 +240,7 @@ def client_factory(
     client_factory.expense_categorizer = transactions_categorizer
     client_factory.plaid = plaid_client
     client_factory.sync_transactions_task_queue = sync_transactions_task_queue
+    client_factory.media_bucket = media_bucket
 
     # return the client factory configured with mock clients
     return client_factory

--- a/tst/database/mock.py
+++ b/tst/database/mock.py
@@ -204,7 +204,7 @@ class MockDDB:
                         "updated_at": {
                             "S": json_account["updated_at"],
                         },
-                        "logo_url": {
+                        "logo_s3_uri": {
                             "S": json_account["logo_url"],
                         },
                         "plaid_account_id": {

--- a/tst/plaid/test_transaction_converter.py
+++ b/tst/plaid/test_transaction_converter.py
@@ -5,6 +5,7 @@ import pytest
 from src.ai.mlp.expenses import ExpenseCategorizerMLP
 from src.database.client import WalterDB
 from src.database.transactions.models import BankTransaction
+from src.media.bucket import MediaBucket
 from src.plaid.transaction_converter import (
     TransactionConversionType,
     TransactionConverter,
@@ -14,9 +15,15 @@ from tst.plaid.utils import create_plaid_transaction
 
 @pytest.fixture
 def transaction_converter(
-    walter_db: WalterDB, transactions_categorizer: ExpenseCategorizerMLP
+    walter_db: WalterDB,
+    transactions_categorizer: ExpenseCategorizerMLP,
+    media_bucket: MediaBucket,
 ) -> TransactionConverter:
-    return TransactionConverter(walter_db, transactions_categorizer)
+    return TransactionConverter(
+        db=walter_db,
+        transaction_categorizer=transactions_categorizer,
+        media_bucket=media_bucket,
+    )
 
 
 def test_transaction_converter_new_transaction(


### PR DESCRIPTION
## Summary

This PR adds a CloudFront CDN to serve the public and private media from the new `WalterBackend` media S3 bucket.

The media S3 bucket serves the purpose of storing and serving public and private static files like logos, profile pictures, and more to the frontend. The directory structure is as follows: 

```txt
> walter-backend-media-dev/
  > public/
  > private/
```

The CDN has access to all the objects in the `public/` directory but none of the objects in the `private/` directory. By default, the CDN can access the public objects and will use pre-signed URL's to access the private objects (to be implemented in a different PR). 

## Context

Serving static content from a CDN is pretty rad! Also, helps with low-latency static file serving to users for the frontend

## Changes

- [X] Add CloudFront CDN to Terraform
- [X] Return CDN URLs for API responses

## Testing

E2E tested in development.

## Notes

N/A
