### PR TITLE
feat: add cdn bucket write permissions to sync transactions workflow

### DIFF
--- a/infra/infrastructure/cdn.tf
+++ b/infra/infrastructure/cdn.tf
@@ -22,12 +22,26 @@ module "cdn_bucket" {
     {
       prefix     = "*",
       principals = concat([], var.cdn_bucket_access_additional_principals)
+    },
+    {
+      prefix = "public/logos/*"
+      principals = [
+        module.workflow_roles["sync_transactions"].role_arn
+      ]
     }
   ]
   write_access_principals = [
     {
-      prefix     = "*",
-      principals = concat([], var.cdn_bucket_access_additional_principals)
+      prefix = "*",
+      principals = concat([
+        module.workflow_roles["sync_transactions"].role_arn
+      ], var.cdn_bucket_access_additional_principals)
+    },
+    {
+      prefix = "public/logos/*"
+      principals = [
+        module.workflow_roles["sync_transactions"].role_arn
+      ]
     }
   ]
   delete_access_principals = [

--- a/infra/infrastructure/modules/iam_s3_access_policy/main.tf
+++ b/infra/infrastructure/modules/iam_s3_access_policy/main.tf
@@ -1,0 +1,96 @@
+locals {
+  # Provided inputs are S3 object prefix ARNs, e.g., arn:aws:s3:::my-bucket/path/*
+  read_prefix_arns   = var.read_access_bucket_prefixes
+  write_prefix_arns  = var.write_access_bucket_prefixes
+  delete_prefix_arns = var.delete_access_bucket_prefixes
+
+  # Extract bucket names from ARN and derive bucket ARNs for ListBucket
+  read_bucket_names = distinct([
+    for arn in local.read_prefix_arns : split("/", replace(arn, "arn:aws:s3:::", ""))[0]
+  ])
+  read_bucket_arns = [for b in local.read_bucket_names : "arn:aws:s3:::${b}"]
+
+  # Derive the key prefixes (without bucket and without trailing *) for ListBucket condition
+  read_key_prefixes = [
+    for arn in local.read_prefix_arns :
+    replace(
+      join("/", slice(
+        split("/", replace(arn, "arn:aws:s3:::", "")),
+        1,
+        length(split("/", replace(arn, "arn:aws:s3:::", "")))
+      )),
+      "*",
+      ""
+    )
+  ]
+}
+
+resource "aws_iam_policy" "this" {
+  name   = var.policy_name
+  policy = data.aws_iam_policy_document.this.json
+}
+
+data "aws_iam_policy_document" "this" {
+  # READ access: list bucket (scoped by key prefix) and get objects
+  dynamic "statement" {
+    for_each = length(local.read_prefix_arns) > 0 ? [1] : []
+    content {
+      sid = "S3ReadBucketAccess"
+
+      actions = [
+        "s3:ListBucket"
+      ]
+
+      resources = local.read_bucket_arns
+
+      condition {
+        test     = "StringLike"
+        variable = "s3:prefix"
+        values   = local.read_key_prefixes
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(local.read_prefix_arns) > 0 ? [1] : []
+    content {
+      sid = "S3ReadObjectAccess"
+
+      actions = [
+        "s3:GetObject",
+        "s3:GetObjectVersion"
+      ]
+
+      resources = local.read_prefix_arns
+    }
+  }
+
+  # WRITE access: put objects
+  dynamic "statement" {
+    for_each = length(local.write_prefix_arns) > 0 ? [1] : []
+    content {
+      sid = "S3WriteObjectAccess"
+
+      actions = [
+        "s3:PutObject"
+      ]
+
+      resources = local.write_prefix_arns
+    }
+  }
+
+  # DELETE access: delete objects
+  dynamic "statement" {
+    for_each = length(local.delete_prefix_arns) > 0 ? [1] : []
+    content {
+      sid = "S3DeleteObjectAccess"
+
+      actions = [
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion"
+      ]
+
+      resources = local.delete_prefix_arns
+    }
+  }
+}

--- a/infra/infrastructure/modules/iam_s3_access_policy/outputs.tf
+++ b/infra/infrastructure/modules/iam_s3_access_policy/outputs.tf
@@ -1,0 +1,19 @@
+output "policy_arn" {
+  description = "ARN of the IAM policy that grants S3 access."
+  value       = aws_iam_policy.this.arn
+}
+
+output "policy_id" {
+  description = "IAM policy id."
+  value       = aws_iam_policy.this.id
+}
+
+output "policy_name" {
+  description = "Name of the IAM policy."
+  value       = aws_iam_policy.this.name
+}
+
+output "policy_document_json" {
+  description = "Rendered JSON of the IAM policy document."
+  value       = data.aws_iam_policy_document.this.json
+}

--- a/infra/infrastructure/modules/iam_s3_access_policy/variables.tf
+++ b/infra/infrastructure/modules/iam_s3_access_policy/variables.tf
@@ -1,0 +1,19 @@
+variable "policy_name" {
+  description = "Optional name for the IAM policy. If not provided, a default name will be used."
+  type        = string
+}
+
+variable "read_access_bucket_prefixes" {
+  description = "List of S3 bucket prefixes to grant READ access to (object read and bucket list)."
+  type        = list(string)
+}
+
+variable "write_access_bucket_prefixes" {
+  description = "List of S3 bucket prefixes to grant WRITE access to (object put)."
+  type        = list(string)
+}
+
+variable "delete_access_bucket_prefixes" {
+  description = "List of S3 bucket prefixes to grant DELETE access to (object delete)."
+  type        = list(string)
+}

--- a/infra/infrastructure/modules/s3_bucket/outputs.tf
+++ b/infra/infrastructure/modules/s3_bucket/outputs.tf
@@ -1,3 +1,7 @@
+output "bucket_arn" {
+  value = aws_s3_bucket.bucket.arn
+}
+
 output "bucket_regional_domain_name" {
   value = aws_s3_bucket.bucket.bucket_regional_domain_name
 }

--- a/infra/infrastructure/modules/workflow_iam_role/variables.tf
+++ b/infra/infrastructure/modules/workflow_iam_role/variables.tf
@@ -53,3 +53,16 @@ variable "additional_principals" {
   type        = list(string)
 }
 
+variable "s3_access" {
+  type = list(object({
+    access_type = string
+    bucket_arn  = string
+    prefixes    = list(string)
+  }))
+
+  validation {
+    condition     = alltrue([for s in var.s3_access : contains(["read", "write", "delete"], s.access_type)])
+    error_message = "access_type must be one of: read, write, delete"
+  }
+}
+

--- a/infra/infrastructure/workflows.tf
+++ b/infra/infrastructure/workflows.tf
@@ -14,6 +14,7 @@ locals {
       ]
       delete_access_table_arns   = []
       receive_message_queue_arns = []
+      s3_access                  = []
       principals = [
         var.workflow_assume_role_additional_principals
       ]
@@ -38,6 +39,13 @@ locals {
       delete_access_table_arns = []
       receive_message_queue_arns = [
         module.queues["sync_transactions"].queue_arn
+      ]
+      s3_access = [
+        {
+          access_type = "write"
+          bucket_arn  = module.cdn_bucket.bucket_arn
+          prefixes    = ["public/logos/*"]
+        }
       ]
       principals = [
         var.workflow_assume_role_additional_principals
@@ -68,6 +76,7 @@ module "workflow_roles" {
   domain                            = var.domain
   description                       = each.value.description
   secrets_access                    = each.value.secrets
+  s3_access                         = each.value.s3_access
   read_table_access_arns            = each.value.read_access_table_arns
   write_table_access_arns           = each.value.write_access_table_arns
   delete_table_access_arns          = each.value.delete_access_table_arns

--- a/src/plaid/transaction_converter.py
+++ b/src/plaid/transaction_converter.py
@@ -14,27 +14,9 @@ from src.database.transactions.models import (
     TransactionType,
 )
 from src.media.bucket import MediaBucket
-from src.plaid.models import PersonalFinanceCategories
 from src.utils.log import Logger
 
 LOG = Logger(__name__).get_logger()
-
-PERSONAL_FINANCE_CATEGORY_TO_TRANSACTION_TYPE: Dict[
-    PersonalFinanceCategories, TransactionType
-] = {
-    PersonalFinanceCategories.ENTERTAINMENT: TransactionType.BANKING,
-    PersonalFinanceCategories.FOOD_AND_DRINK: TransactionType.BANKING,
-    PersonalFinanceCategories.GENERAL_MERCHANDISE: TransactionType.BANKING,
-    PersonalFinanceCategories.GENERAL_SERVICES: TransactionType.BANKING,
-    PersonalFinanceCategories.INCOME: TransactionType.BANKING,
-    PersonalFinanceCategories.LOAN_PAYMENTS: TransactionType.BANKING,
-    PersonalFinanceCategories.PERSONAL_CARE: TransactionType.BANKING,
-    PersonalFinanceCategories.TRANSPORTATION: TransactionType.BANKING,
-    PersonalFinanceCategories.TRAVEL: TransactionType.BANKING,
-    PersonalFinanceCategories.OTHER: TransactionType.BANKING,
-    PersonalFinanceCategories.TRANSFER_OUT: TransactionType.BANKING,
-}
-"""(dict): Mapping of personal finance categories to transaction types"""
 
 
 class TransactionConversionType(Enum):


### PR DESCRIPTION
## Summary

This PR adds read/write permissions to the CDN bucket for the `SyncTransactions` workflow IAM role.

This workflow is responsible for ingesting new transaction data from Plaid and persisting the results to WalterDB. The ingestion logic ensures that the converted transactions are tied to transaction entities that exist in WalterDB with correct account and user mappings as well as other validations.

Part of this process involves uploading non-null merchant logos to the CDN bucket for new merchant logos. This allows `WalterBackend` to maintain an S3 bucket with merchant logos for frontend displays. However, the workflow IAM role was lacking read/write access on the CDN bucket so it was failing. This PR fixes that.

## Context

The `SyncTransactions` workflow IAM role requires read/write access to CDN bucket to upload new merchant logos from Plaid

## Changes

- [X] The `SyncTransactions` workflow IAM role Terraform module was updated to include S3 access
- [X] New IAM S3 access policy Terraform module was created to easily create S3 access policies
- [X] The bucket policy of the CDN bucket was updated to allow read/write access from `SyncTransactions` workflow role on the `public/logos/*` prefix where the merchant logos are stored

## Testing

E2E testing development.

<img width="1725" height="1030" alt="Screenshot 2025-09-25 at 4 28 56 PM" src="https://github.com/user-attachments/assets/f02857f9-ce96-4a7c-be89-17cfe2c1bbd6" />

## Notes

N/A
