### PR TITLE
fix: fix failing canaries

### DIFF
--- a/src/canaries/accounts/get_accounts.py
+++ b/src/canaries/accounts/get_accounts.py
@@ -73,6 +73,7 @@ class GetAccounts(BaseCanary):
             match account_type:
                 case AccountType.DEPOSITORY | AccountType.CREDIT | AccountType.LOAN:
                     required_account_fields = [
+                        ("linked_with_plaid", None),
                         ("account_id", None),
                         ("institution_name", None),
                         ("account_name", None),
@@ -83,6 +84,7 @@ class GetAccounts(BaseCanary):
                     ]
                 case AccountType.INVESTMENT:
                     required_account_fields = [
+                        ("linked_with_plaid", None),
                         ("account_id", None),
                         ("institution_name", None),
                         ("account_name", None),

--- a/src/canaries/transactions/get_transactions.py
+++ b/src/canaries/transactions/get_transactions.py
@@ -92,7 +92,9 @@ class GetTransactions(BaseCanary):
                 ("transaction_category", "Restaurants"),
                 ("transaction_date", "2025-08-01"),
                 ("merchant_name", "Canary Coffee"),
+                ("merchant_logo_url", None),
                 ("transaction_amount", 5.0),
+                ("is_plaid_transaction", False),
             ],
             "bank-txn-7016361254": [
                 ("account_id", "acct-5782898837"),
@@ -106,7 +108,9 @@ class GetTransactions(BaseCanary):
                 ("transaction_category", "Entertainment"),
                 ("transaction_date", "2025-08-01"),
                 ("merchant_name", "Canary Concert Tickets"),
+                ("merchant_logo_url", None),
                 ("transaction_amount", 100.0),
+                ("is_plaid_transaction", False),
             ],
             "investment-txn-7017568759": [
                 ("account_id", "acct-5782388299"),
@@ -122,7 +126,9 @@ class GetTransactions(BaseCanary):
                 ("transaction_category", "Investment"),
                 ("price_per_share", 100.0),
                 ("quantity", 10.0),
+                ("merchant_logo_url", None),
                 ("transaction_amount", 1000.0),
+                ("is_plaid_transaction", False),
             ],
         }
 


### PR DESCRIPTION
## Summary

The `GetAccounts` and `GetTransactions` API canaries are failing after updating the response objects for the respective APIs. 

I forgot to update the corresponding canaries so they were erroring out when the response contained additional unknown fields.

## Context

The canaries need to be testing API health successfully.

## Changes

- [X] Update `GetAccounts` and `GetTransactions` API canaries to handle new response fields

## Testing

E2E testing in development.

<img width="1640" height="546" alt="Screenshot 2025-09-25 at 5 06 27 PM" src="https://github.com/user-attachments/assets/915701be-0d76-480a-bcf8-20fbcfc05004" />

## Notes

N/A