### PR TITLE
feat: require api key for all endpoints

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -61,6 +61,7 @@ jobs:
           PLAID_SECRET: ${{ secrets.PLAID_SECRET }}
           POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          WALTER_BACKEND_API_KEY: ${{ secrets.WALTER_BACKEND_API_KEY }}
         run: |
           ./infra/scripts/plan.sh dev
         continue-on-error: true

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -28,6 +28,8 @@ public_subnet_cidr  = "10.0.0.0/28"  # 16 public IPs (AWS reserves 5 IPs) = 11 u
 private_subnet_cidr = "10.0.0.16/28" # 16 private IPs (AWS reserves 5 IPs) = 11 usable IPs
 
 # WalterBackend API settings
+api_rate_limit                        = 5
+api_burst_limit                       = 10
 api_timeout_seconds                   = 15
 api_lambda_memory_mb                  = 1024
 api_provisioned_concurrent_executions = 0

--- a/infra/infrastructure/api.tf
+++ b/infra/infrastructure/api.tf
@@ -389,6 +389,7 @@ module "api_custom_domain" {
 
 module "api" {
   source                = "./modules/api_gateway"
+  domain                = var.domain
   name                  = local.NAME
   description           = local.DESCRIPTION
   function_name         = module.functions["api"].function_name
@@ -396,6 +397,9 @@ module "api" {
   image_digest          = module.repositories["walter_backend"].image_digest
   stage_name            = local.STAGE_NAME
   log_retention_in_days = var.log_retention_in_days
+  api_key_value         = var.walter_backend_api_key
+  rate_limit            = var.api_rate_limit
+  burst_limit           = var.api_burst_limit
 }
 
 resource "aws_api_gateway_resource" "auth" {
@@ -432,6 +436,7 @@ module "endpoints" {
   resource_id       = module.resources[each.value.path].resource_id
   http_method       = each.value.method
   lambda_invoke_arn = module.functions["api"].invoke_arn
+  api_key_required  = true # API key required for all endpoints to ensure known callers
 }
 
 /***************************

--- a/infra/infrastructure/modules/api_gateway/main.tf
+++ b/infra/infrastructure/modules/api_gateway/main.tf
@@ -7,6 +7,32 @@ resource "aws_api_gateway_rest_api" "api" {
   }
 }
 
+resource "aws_api_gateway_usage_plan" "usage_plan" {
+  name        = "${var.name}-UsagePlan-${var.domain}"
+  description = "The usage plan for making API calls to WalterBackend API. (${var.domain})"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.api.id
+    stage  = var.stage_name
+  }
+
+  throttle_settings {
+    rate_limit  = var.rate_limit
+    burst_limit = var.burst_limit
+  }
+}
+
+resource "aws_api_gateway_usage_plan_key" "example" {
+  key_id        = aws_api_gateway_api_key.api_key.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.usage_plan.id
+}
+
+resource "aws_api_gateway_api_key" "api_key" {
+  name  = "${var.name}-Key-${var.domain}"
+  value = var.api_key_value
+}
+
 resource "aws_lambda_permission" "api_invoke_function" {
   statement_id  = "AllowAPIGatewayLambdaInvocation"
   action        = "lambda:InvokeFunction"

--- a/infra/infrastructure/modules/api_gateway/main.tf
+++ b/infra/infrastructure/modules/api_gateway/main.tf
@@ -13,7 +13,7 @@ resource "aws_api_gateway_usage_plan" "usage_plan" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.api.id
-    stage  = var.stage_name
+    stage  = aws_api_gateway_stage.api_stage.stage_name
   }
 
   throttle_settings {

--- a/infra/infrastructure/modules/api_gateway/variables.tf
+++ b/infra/infrastructure/modules/api_gateway/variables.tf
@@ -1,3 +1,13 @@
+variable "domain" {
+  description = "The domain of WalterBackend."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "stg", "prod"], var.domain)
+    error_message = "The domain must be 'dev', 'stg', or 'prod'."
+  }
+}
+
 variable "name" {
   description = "The name of the API Gateway."
   type        = string
@@ -30,5 +40,20 @@ variable "stage_name" {
 
 variable "log_retention_in_days" {
   description = "The number of days to retain API Gateway logs."
+  type        = number
+}
+
+variable "api_key_value" {
+  description = "The value of the API key used to restrict access to the API Gateway to known callers."
+  type        = string
+}
+
+variable "rate_limit" {
+  description = "The steady-state number of requests per second allowed to the API before throttling occurs."
+  type        = number
+}
+
+variable "burst_limit" {
+  description = "The maximum number of requests that the API can handle in a short burst before throttling."
   type        = number
 }

--- a/infra/infrastructure/modules/api_gateway_endpoint/main.tf
+++ b/infra/infrastructure/modules/api_gateway_endpoint/main.tf
@@ -1,8 +1,9 @@
 resource "aws_api_gateway_method" "endpoint_method" {
-  rest_api_id   = var.rest_api_id
-  resource_id   = var.resource_id
-  http_method   = var.http_method
-  authorization = "NONE"
+  rest_api_id      = var.rest_api_id
+  resource_id      = var.resource_id
+  http_method      = var.http_method
+  authorization    = "NONE"
+  api_key_required = true
 }
 
 resource "aws_api_gateway_integration" "endpoint_integration" {

--- a/infra/infrastructure/modules/api_gateway_endpoint/variables.tf
+++ b/infra/infrastructure/modules/api_gateway_endpoint/variables.tf
@@ -17,3 +17,8 @@ variable "lambda_invoke_arn" {
   description = "The Lambda function invoke ARN"
   type        = string
 }
+
+variable "api_key_required" {
+  description = "Whether the endpoint requires an API key or not."
+  type        = string
+}

--- a/infra/infrastructure/secrets.tf
+++ b/infra/infrastructure/secrets.tf
@@ -19,14 +19,18 @@ locals {
     Stripe = {
       STRIPE_SECRET_KEY = var.stripe_secret_key
     }
+    WalterBackendAPIKey = {
+      WALTER_BACKEND_API_KEY = var.walter_backend_api_key
+    }
   }
 
   DESCRIPTIONS = {
-    Auth    = "The secret keys used for authentication by WalterBackend to sign and verify API requests. (${var.domain})"
-    Datadog = "The Datadog secret keys used by WalterBackend to emit metrics and send logs to Datadog for dashboards and monitoring. (${var.domain})"
-    Plaid   = "The Plaid client ID and secret used by WalterBackend to authenticate with Plaid. (${var.domain})"
-    Polygon = "The Polygon API key used to make requests to Polygon. (${var.domain})"
-    Stripe  = "The secret key used to interact with Stripe for customer billing. (${var.domain})"
+    Auth                = "The secret keys used for authentication by WalterBackend to sign and verify API requests. (${var.domain})"
+    Datadog             = "The Datadog secret keys used by WalterBackend to emit metrics and send logs to Datadog for dashboards and monitoring. (${var.domain})"
+    Plaid               = "The Plaid client ID and secret used by WalterBackend to authenticate with Plaid. (${var.domain})"
+    Polygon             = "The Polygon API key used to make requests to Polygon. (${var.domain})"
+    Stripe              = "The secret key used to interact with Stripe for customer billing. (${var.domain})"
+    WalterBackendAPIKey = "The API key used to make calls to the WalterBackend API. (${var.domain})"
   }
 }
 

--- a/infra/infrastructure/variables.tf
+++ b/infra/infrastructure/variables.tf
@@ -82,6 +82,17 @@ variable "private_subnet_cidr" {
   type        = string
 }
 
+variable "api_rate_limit" {
+  description = "The steady-state number of requests per second allowed to the WalterBackend API before throttling occurs."
+  type        = number
+}
+
+variable "api_burst_limit" {
+  description = "The maximum number of requests that the WalterBackend API can handle in a short burst before throttling."
+  type        = number
+}
+
+
 variable "api_function_version" {
   description = "The WalterBackend-API Lambda function version to use for API requests."
   type        = number
@@ -228,6 +239,15 @@ variable "sync_transactions_max_retry_attempts" {
   }
 }
 
+variable "cdn_bucket_access_additional_principals" {
+  description = "The list of additional AWS principal(s) allowed to access the CDN S3 bucket."
+  type        = list(string)
+}
+
+/**********************************
+ * WalterBackend Secret Variables *
+ **********************************/
+
 variable "access_token_secret_key" {
   description = "The secret key used to create access tokens used for API authentication."
   type        = string
@@ -273,8 +293,8 @@ variable "stripe_secret_key" {
   type        = string
 }
 
-variable "cdn_bucket_access_additional_principals" {
-  description = "The list of additional AWS principal(s) allowed to access the CDN S3 bucket."
-  type        = list(string)
+variable "walter_backend_api_key" {
+  description = "The API key used to make calls to the WalterBackend API."
+  type        = string
 }
 

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -164,6 +164,7 @@ set_environment_variables() {
         "PLAID_SECRET"
         "POLYGON_API_KEY"
         "STRIPE_SECRET_KEY"
+        "WALTER_BACKEND_API_KEY"
     )
 
     # Function to check if all required vars are set
@@ -270,6 +271,7 @@ run_terraform() {
         -var="api_function_version=$API_FUNCTION_VERSION"
         -var="canary_function_version=$CANARY_FUNCTION_VERSION"
         -var="workflow_function_version=$WORKFLOW_FUNCTION_VERSION"
+        -var="walter_backend_api_key=$WALTER_BACKEND_API_KEY"
     )
 
     # Run the specified action


### PR DESCRIPTION
## Summary

This PR adds an API key that is now required for all `WalterBackend` API endpoints.

This is a security improvement as it restricts API callers to known entities with keys. Also, it's a pretty quick win as the impl leverages native API Gateway functionality (with throttling and quotas) so quick addition with great benefit!

The secret is stored in Secrets Manager and accessible via API Gateway in the console.

## Context

`WalterBackend` API callers should be restricted to known set of entities.

## Changes

- [X] Add API key in Terraform
- [X] Require all API endpoints to use key

## Testing

E2E testing in development.

<img width="920" height="440" alt="Screenshot 2025-09-25 at 7 17 14 PM" src="https://github.com/user-attachments/assets/ca98ad16-d195-4899-8e50-564eab508657" />

## Notes

API Gateway provided this functionality essentially out of the box! Good infra design here 🚀 
