### PR TITLE
feat: disable datadog logs

### DIFF
--- a/infra/infrastructure/modules/api_gateway/main.tf
+++ b/infra/infrastructure/modules/api_gateway/main.tf
@@ -20,9 +20,11 @@ resource "aws_api_gateway_usage_plan" "usage_plan" {
     rate_limit  = var.rate_limit
     burst_limit = var.burst_limit
   }
+
+  depends_on = [aws_api_gateway_deployment.api_deployment]
 }
 
-resource "aws_api_gateway_usage_plan_key" "example" {
+resource "aws_api_gateway_usage_plan_key" "usage_plan_key" {
   key_id        = aws_api_gateway_api_key.api_key.id
   key_type      = "API_KEY"
   usage_plan_id = aws_api_gateway_usage_plan.usage_plan.id

--- a/infra/infrastructure/modules/lamdba_function/main.tf
+++ b/infra/infrastructure/modules/lamdba_function/main.tf
@@ -31,6 +31,7 @@ resource "aws_lambda_function" "this" {
       DD_LOG_LEVEL      = var.log_level
       DD_API_KEY        = var.datadog_api_key
       DD_SITE           = var.datadog_site
+      DD_LOGS_ENABLED   = false
       DD_TRACE_ENABLED  = false
       DOMAIN            = var.domain
       LOG_LEVEL         = var.log_level


### PR DESCRIPTION
## Summary

This PR disables [Datadog log collection and indexing](https://docs.datadoghq.com/agent/logs/?tab=tailfiles).

I migrated Walter's monitoring to Datadog since CloudWatch is expensive (not really at low-scale though) and I don't want to use exclusively AWS products (other better products exist 😄). After migration, the cost metrics for Datadog seemed fine except for the log collection and indexing. 

Walter easily produces millions of logs per month with just canary traffic and having Datadog collect and index these logs when CloudWatch doest the same thing for much much less is silly. This PR disables solely the Datadog log collection for Walter serverless functions to reduce costs.

This PR should bring total Datadog costs down from $120/month -> $50/month with the latter number not scaling too hard (i.e. much more usage shouldn't equal a massive spike in cost). 

## Context

Because building your own app is expensive and I pay for this myself. Walter really isn't even that complex and is easily > $75/month in infrastructure costs between AWS + Datadog.

## Changes

- [X] Disable Datadog log collection and indexing for Walter serverless functions

## Testing

E2E testing in `dev`.

## Notes

N/A - CloudWatch already provides a great way to index and search logs easily with log insights - this feature of Datadog is not needed. 