### PR TITLE
fix: add api key to canaries

### DIFF
--- a/infra/infrastructure/functions.tf
+++ b/infra/infrastructure/functions.tf
@@ -10,6 +10,7 @@ locals {
       memory_size                       = var.api_lambda_memory_mb
       lambda_handler                    = "walter.api_entrypoint"
       provisioned_concurrent_executions = var.api_provisioned_concurrent_executions
+      additional_env_vars               = {}
     },
     canary = {
       name                              = "WalterBackend-Canary-${var.domain}"
@@ -21,6 +22,9 @@ locals {
       memory_size                       = var.canary_lambda_memory_mb
       lambda_handler                    = "walter.canaries_entrypoint"
       provisioned_concurrent_executions = var.canary_provisioned_concurrent_executions
+      additional_env_vars = {
+        "WALTER_BACKEND_API_KEY" = var.walter_backend_api_key
+      }
     },
     workflow = {
       name                              = "WalterBackend-Workflow-${var.domain}"
@@ -32,6 +36,7 @@ locals {
       memory_size                       = var.workflow_lambda_memory_mb
       lambda_handler                    = "walter.workflows_entrypoint"
       provisioned_concurrent_executions = var.workflow_provisioned_concurrent_executions
+      additional_env_vars               = {}
     }
   }
 
@@ -98,6 +103,7 @@ module "functions" {
   security_group_ids                = [module.network.function_sg_id]
   subnet_ids                        = [module.network.private_subnet_id]
   env_vars_kms_key_arn              = module.env_vars_key.arn
+  additional_env_vars               = each.value.additional_env_vars
 }
 
 /************************************

--- a/infra/infrastructure/modules/lamdba_function/main.tf
+++ b/infra/infrastructure/modules/lamdba_function/main.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "this" {
   }
 
   environment {
-    variables = {
+    variables = merge({
       DD_LAMBDA_HANDLER = var.lambda_handler
       DD_LOG_LEVEL      = var.log_level
       DD_API_KEY        = var.datadog_api_key
@@ -35,7 +35,7 @@ resource "aws_lambda_function" "this" {
       DD_TRACE_ENABLED  = false
       DOMAIN            = var.domain
       LOG_LEVEL         = var.log_level
-    }
+    }, var.additional_env_vars)
   }
 
   kms_key_arn = var.env_vars_kms_key_arn

--- a/infra/infrastructure/modules/lamdba_function/variables.tf
+++ b/infra/infrastructure/modules/lamdba_function/variables.tf
@@ -96,3 +96,8 @@ variable "env_vars_kms_key_arn" {
   description = "ARN of the KMS key used to encrypt environment variables."
   type        = string
 }
+
+variable "additional_env_vars" {
+  description = "The additional environment variables to add to the Lambda function."
+  type        = map(string)
+}

--- a/src/canaries/accounts/get_accounts.py
+++ b/src/canaries/accounts/get_accounts.py
@@ -28,12 +28,18 @@ class GetAccounts(BaseCanary):
 
     def __init__(
         self,
+        api_key: str,
         authenticator: WalterAuthenticator,
         db: WalterDB,
         metrics: DatadogMetricsClient,
     ) -> None:
         super().__init__(
-            GetAccounts.CANARY_NAME, GetAccounts.API_URL, authenticator, db, metrics
+            GetAccounts.CANARY_NAME,
+            GetAccounts.API_URL,
+            api_key,
+            authenticator,
+            db,
+            metrics,
         )
 
     def is_authenticated(self) -> bool:
@@ -42,7 +48,10 @@ class GetAccounts(BaseCanary):
     def call_api(self, tokens: Optional[Tokens] = None) -> Response:
         return requests.get(
             GetAccounts.API_URL,
-            headers={"Authorization": f"Bearer {tokens.access_token}"},
+            headers={
+                "Authorization": f"Bearer {tokens.access_token}",
+                "x-api-key": self.api_key,
+            },
         )
 
     def validate_cookies(self, cookies: RequestsCookieJar) -> None:

--- a/src/canaries/auth/login.py
+++ b/src/canaries/auth/login.py
@@ -27,11 +27,14 @@ class Login(BaseCanary):
 
     def __init__(
         self,
+        api_key: str,
         authenticator: WalterAuthenticator,
         db: WalterDB,
         metrics: DatadogMetricsClient,
     ) -> None:
-        super().__init__(Login.API_NAME, Login.API_URL, authenticator, db, metrics)
+        super().__init__(
+            Login.API_NAME, Login.API_URL, api_key, authenticator, db, metrics
+        )
 
     def is_authenticated(self) -> bool:
         return False
@@ -39,7 +42,7 @@ class Login(BaseCanary):
     def call_api(self, tokens: Optional[Tokens] = None) -> Response:
         api_response = requests.post(
             Login.API_URL,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", "x-api-key": self.api_key},
             json={
                 "email": self.CANARY_USER_EMAIL,
                 "password": self.CANARY_USER_PASSWORD,

--- a/src/canaries/auth/logout.py
+++ b/src/canaries/auth/logout.py
@@ -24,11 +24,14 @@ class Logout(BaseCanary):
 
     def __init__(
         self,
+        api_key: str,
         authenticator: WalterAuthenticator,
         db: WalterDB,
         metrics: DatadogMetricsClient,
     ) -> None:
-        super().__init__(Logout.API_NAME, Logout.API_URL, authenticator, db, metrics)
+        super().__init__(
+            Logout.API_NAME, Logout.API_URL, api_key, authenticator, db, metrics
+        )
 
     def is_authenticated(self) -> bool:
         return True
@@ -36,7 +39,10 @@ class Logout(BaseCanary):
     def call_api(self, tokens: Optional[Tokens] = None) -> Response:
         return requests.post(
             Logout.API_URL,
-            headers={"Authorization": f"Bearer {tokens.access_token}"},
+            headers={
+                "Authorization": f"Bearer {tokens.access_token}",
+                "x-api-key": self.api_key,
+            },
         )
 
     def validate_cookies(self, cookies: RequestsCookieJar) -> None:

--- a/src/canaries/auth/refresh.py
+++ b/src/canaries/auth/refresh.py
@@ -24,18 +24,25 @@ class Refresh(BaseCanary):
 
     def __init__(
         self,
+        api_key: str,
         authenticator: WalterAuthenticator,
         db: WalterDB,
         metrics: DatadogMetricsClient,
     ) -> None:
-        super().__init__(Refresh.API_NAME, Refresh.API_URL, authenticator, db, metrics)
+        super().__init__(
+            Refresh.API_NAME, Refresh.API_URL, api_key, authenticator, db, metrics
+        )
 
     def is_authenticated(self) -> bool:
         return True
 
     def call_api(self, tokens: Optional[Tokens] = None) -> Response:
         return requests.post(
-            Refresh.API_URL, headers={"Authorization": f"Bearer {tokens.refresh_token}"}
+            Refresh.API_URL,
+            headers={
+                "Authorization": f"Bearer {tokens.refresh_token}",
+                "x-api-key": self.api_key,
+            },
         )
 
     def validate_cookies(self, cookies: RequestsCookieJar) -> None:

--- a/src/canaries/common/canary.py
+++ b/src/canaries/common/canary.py
@@ -51,12 +51,14 @@ class BaseCanary(ABC):
         self,
         api_name: str,
         api_url: str,
+        api_key: str,
         authenticator: WalterAuthenticator,
         db: WalterDB,
         metrics: DatadogMetricsClient,
     ) -> None:
         self.api_name = api_name
         self.api_url = api_url
+        self.api_key = api_key
         self.authenticator = authenticator
         self.db = db
         self.metrics = metrics

--- a/src/canaries/factory.py
+++ b/src/canaries/factory.py
@@ -65,6 +65,7 @@ class CanaryFactory:
     CANARY_ROLE_NAME_FORMAT = "WalterBackend-Canary-{method}-Role-{domain}"
 
     client_factory: ClientFactory
+    api_key: str
 
     def __post_init__(self) -> None:
         LOG.debug("Creating CanaryFactory")
@@ -82,42 +83,49 @@ class CanaryFactory:
         match canary_type:
             case CanaryType.LOGIN:
                 return Login(
+                    api_key=self.api_key,
                     authenticator=self.client_factory.get_authenticator(),
                     db=self.client_factory.get_db_client(),
                     metrics=self.client_factory.get_metrics_client(),
                 )
             case CanaryType.REFRESH:
                 return Refresh(
+                    api_key=self.api_key,
                     authenticator=self.client_factory.get_authenticator(),
                     db=self.client_factory.get_db_client(),
                     metrics=self.client_factory.get_metrics_client(),
                 )
             case CanaryType.LOGOUT:
                 return Logout(
+                    api_key=self.api_key,
                     authenticator=self.client_factory.get_authenticator(),
                     db=self.client_factory.get_db_client(),
                     metrics=self.client_factory.get_metrics_client(),
                 )
             case CanaryType.GET_USER:
                 return GetUser(
+                    api_key=self.api_key,
                     authenticator=self.client_factory.get_authenticator(),
                     db=self.client_factory.get_db_client(),
                     metrics=self.client_factory.get_metrics_client(),
                 )
             case CanaryType.CREATE_USER:
                 return CreateUser(
+                    api_key=self.api_key,
                     authenticator=self.client_factory.get_authenticator(),
                     db=self.client_factory.get_db_client(),
                     metrics=self.client_factory.get_metrics_client(),
                 )
             case CanaryType.GET_ACCOUNTS:
                 return GetAccounts(
+                    api_key=self.api_key,
                     authenticator=self.client_factory.get_authenticator(),
                     db=self.client_factory.get_db_client(),
                     metrics=self.client_factory.get_metrics_client(),
                 )
             case CanaryType.GET_TRANSACTIONS:
                 return GetTransactions(
+                    api_key=self.api_key,
                     authenticator=self.client_factory.get_authenticator(),
                     db=self.client_factory.get_db_client(),
                     metrics=self.client_factory.get_metrics_client(),

--- a/src/canaries/routing/router.py
+++ b/src/canaries/routing/router.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 
 from src.canaries.common.canary import BaseCanary
@@ -7,6 +8,9 @@ from src.factory import ClientFactory
 from src.utils.log import Logger
 
 log = Logger(__name__).get_logger()
+
+WALTER_BACKEND_API_KEY = os.getenv("WALTER_BACKEND_API_KEY", None)
+"""(str): The API key used to authenticate client requests with the WalterBackend API."""
 
 
 @dataclass
@@ -20,7 +24,9 @@ class CanaryRouter:
     def __post_init__(self) -> None:
         log.debug("Initializing CanaryRouter")
         self.client_factory = ClientFactory(region=AWS_REGION, domain=DOMAIN)
-        self.canary_factory = CanaryFactory(client_factory=self.client_factory)
+        self.canary_factory = CanaryFactory(
+            client_factory=self.client_factory, api_key=WALTER_BACKEND_API_KEY
+        )
 
     def get_canary(self, canary_type: CanaryType) -> BaseCanary:
         log.info(f"Getting '{canary_type.value}' canary'")

--- a/src/canaries/transactions/get_transactions.py
+++ b/src/canaries/transactions/get_transactions.py
@@ -30,6 +30,7 @@ class GetTransactions(BaseCanary):
 
     def __init__(
         self,
+        api_key: str,
         authenticator: WalterAuthenticator,
         db: WalterDB,
         metrics: DatadogMetricsClient,
@@ -37,6 +38,7 @@ class GetTransactions(BaseCanary):
         super().__init__(
             GetTransactions.CANARY_NAME,
             GetTransactions.API_URL,
+            api_key,
             authenticator,
             db,
             metrics,
@@ -48,7 +50,10 @@ class GetTransactions(BaseCanary):
     def call_api(self, tokens: Optional[Tokens] = None) -> Response:
         return requests.get(
             GetTransactions.API_URL,
-            headers={"Authorization": f"Bearer {tokens.access_token}"},
+            headers={
+                "Authorization": f"Bearer {tokens.access_token}",
+                "x-api-key": self.api_key,
+            },
         )
 
     def validate_cookies(self, cookies: RequestsCookieJar) -> None:

--- a/src/canaries/users/create_user.py
+++ b/src/canaries/users/create_user.py
@@ -34,12 +34,18 @@ class CreateUser(BaseCanary):
 
     def __init__(
         self,
+        api_key: str,
         authenticator: WalterAuthenticator,
         db: WalterDB,
         metrics: DatadogMetricsClient,
     ) -> None:
         super().__init__(
-            CreateUser.CANARY_NAME, CreateUser.API_URL, authenticator, db, metrics
+            CreateUser.CANARY_NAME,
+            CreateUser.API_URL,
+            api_key,
+            authenticator,
+            db,
+            metrics,
         )
 
     def is_authenticated(self) -> bool:
@@ -48,7 +54,7 @@ class CreateUser(BaseCanary):
     def call_api(self, tokens: Optional[Tokens] = None) -> Response:
         return requests.post(
             CreateUser.API_URL,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", "x-api-key": self.api_key},
             json={
                 "email": self.NEW_USER_EMAIL,
                 "first_name": self.NEW_USER_FIRST_NAME,

--- a/src/canaries/users/get_user.py
+++ b/src/canaries/users/get_user.py
@@ -30,12 +30,13 @@ class GetUser(BaseCanary):
 
     def __init__(
         self,
+        api_key: str,
         authenticator: WalterAuthenticator,
         db: WalterDB,
         metrics: DatadogMetricsClient,
     ) -> None:
         super().__init__(
-            GetUser.CANARY_NAME, GetUser.API_URL, authenticator, db, metrics
+            GetUser.CANARY_NAME, GetUser.API_URL, api_key, authenticator, db, metrics
         )
 
     def is_authenticated(self) -> bool:
@@ -44,7 +45,10 @@ class GetUser(BaseCanary):
     def call_api(self, tokens: Optional[Tokens] = None) -> Response:
         return requests.get(
             GetUser.API_URL,
-            headers={"Authorization": f"Bearer {tokens.access_token}"},
+            headers={
+                "Authorization": f"Bearer {tokens.access_token}",
+                "x-api-key": self.api_key,
+            },
         )
 
     def validate_cookies(self, cookies: RequestsCookieJar) -> None:

--- a/tst/canary/test_login_canary.py
+++ b/tst/canary/test_login_canary.py
@@ -11,6 +11,7 @@ def login_canary(
     client_factory: ClientFactory,
 ) -> Login:
     return Login(
+        api_key="test-api-key",
         authenticator=client_factory.get_authenticator(),
         db=client_factory.get_db_client(),
         metrics=client_factory.get_metrics_client(),


### PR DESCRIPTION
## Summary

This PR adds the new API key for WalterBackend to the canaries.

After adding the API key to WalterBackend API, the canaries began to fail as they were making test API calls without the key. This PR updates the canaries to use the new key so that API calls do not fail and the canaries can successfully test API health again.

## Context

All of the WalterBackend canaries were consistently failing due to the missing API key. 

## Changes

- [X] Add WalterBackend API key to canaries

## Testing

E2E testing in `dev`.

## Notes

N/A
